### PR TITLE
feat: add Cloudflare Workers deployment

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -34,4 +34,10 @@ jobs:
         run: uv run python -m compileall -q backend server.py worker.py
 
       - name: Dry-run Cloudflare bundle
-        run: uv run pywrangler deploy --dry-run --outdir .worker-dist
+        shell: bash
+        run: |
+          set +e
+          uv run pywrangler deploy --dry-run --outdir .worker-dist > /tmp/pywrangler.log 2>&1
+          code=$?
+          tail -n 120 /tmp/pywrangler.log
+          exit $code

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -1,0 +1,37 @@
+name: Cloudflare Worker
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  validate-worker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Sync Python dependencies
+        run: uv sync --group dev --python 3.13
+
+      - name: Verify stateless tickets
+        run: uv run python tests/test_cloudflare_ticket.py
+
+      - name: Compile Python sources
+        run: uv run python -m compileall -q backend server.py worker.py
+
+      - name: Dry-run Cloudflare bundle
+        run: uv run pywrangler deploy --dry-run --outdir .worker-dist

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ __pycache__/
 data/*.sqlite3
 data/*.db
 
+# --- Cloudflare Python Workers ---
+.venv-workers/
+python_modules/
+.wrangler/
+.dev.vars
+
 # --- scraper secrets & archive ---
 .scraper_token.txt
 .scraper_jwt.txt

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nori.Web - NoriOS 本地兼容后端与离线服务
 
-[![GitHub](https://img.shields.io/badge/GitHub-FuturumTech%2FNori.Web-blue?logo=github)](https://github.com/FuturumTech/Nori.Web)
+[![GitHub](https://img.shields.io/badge/GitHub-MF--Dust%2FNori.Web-blue?logo=github)](https://github.com/MF-Dust/Nori.Web)
 [![Python](https://img.shields.io/badge/Python-3.11%2B-brightgreen?logo=python)](https://www.python.org/)
 [![License](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 
@@ -18,6 +18,11 @@
   - **主通道 WebSocket (`/api/arcade/web/v1`)**：支持 `arcade.v1` 子协议、ticket 校验、世界生命周期管理（创建/加入/重置/挂载/卸载）、版本栅栏同步与双向事件分发。
   - **媒体流 WebSocket (`/api/arcade/web/v1/media`)**：支持 `open_media` 授权与 `chatAudio` 二进制音频帧推送。
   - **Better-Auth 兼容**：内置本地会话、访客自动登录、开发 OTP 验证及 Convex 兼容端点。
+- **Cloudflare Workers 部署支持**
+  - Python Workers + FastAPI ASGI 后端。
+  - Workers Static Assets 托管 SPA、Live2D、音效和桌面资源。
+  - Durable Objects 将同一 Arcade ticket 的主通道与媒体通道路由到同一状态所有者。
+  - 签名 WebSocket ticket 可跨 Worker isolate 验证，不依赖单进程内存。
 - **全套内置卡带状态机 (Cartridges)**
   - 💬 **Chat**：支持操作/分块/音频确认状态机，可无缝对接 OpenAI 兼容接口，未配置时提供本地智能回退。
   - 🍰 **Cake Duel**：支持完整基础牌组规则、回合轮替、虚张声势/质疑机制、蛋糕结算与本地 AI 对手。
@@ -31,7 +36,7 @@
 
 ---
 
-## 🚀 快速开始
+## 🚀 本地运行
 
 ### 运行环境要求
 - **Python** 3.11 或更高版本（已在 Python 3.11 / 3.13 验证）
@@ -40,9 +45,15 @@
 ### 1. 安装依赖
 
 ```bash
-git clone https://github.com/FuturumTech/Nori.Web.git
+git clone https://github.com/MF-Dust/Nori.Web.git
 cd Nori.Web
-python -m pip install -r requirements.txt
+python -m pip install -e ".[local]"
+```
+
+也可以使用 `uv`：
+
+```bash
+uv sync --extra local
 ```
 
 ### 2. 启动服务
@@ -59,15 +70,70 @@ python server.py
 
 ---
 
+## ☁️ Cloudflare Workers 部署
+
+项目根目录已经包含 `worker.py` 与 `wrangler.jsonc`，部署结构如下：
+
+```text
+Browser
+  ├─ /assets, Live2D, audio ... → Workers Static Assets
+  ├─ /api/*                    → FastAPI / Python Worker
+  └─ Arcade WebSocket          → Durable Object per signed ticket
+```
+
+### 1. 准备 Cloudflare Python Workers 环境
+
+需要安装 Node.js 与 `uv`，然后同步 Worker 依赖：
+
+```bash
+uv sync --group dev
+```
+
+### 2. 本地运行 Cloudflare Worker
+
+```bash
+uv run pywrangler dev
+```
+
+### 3. 配置部署 Secret
+
+生产部署建议至少设置一个独立的 `SECRET_KEY`，用于签名 Arcade WebSocket ticket：
+
+```bash
+uv run pywrangler secret put SECRET_KEY
+```
+
+如需启用 OpenAI 兼容接口：
+
+```bash
+uv run pywrangler secret put OPENAI_API_KEY
+```
+
+`OPENAI_BASE_URL` 和 `OPENAI_MODEL` 可以继续放在 Workers Vars 中；代码会从 Cloudflare runtime bindings 动态读取这些配置。
+
+### 4. 部署
+
+```bash
+uv run pywrangler deploy
+```
+
+Cloudflare 部署默认设置 `NORI_DISABLE_LIVE_PACK=1`，因此不会加载本地账号的 `live_world_pack.json` 内容。若是私有部署并明确希望启用归档，可修改 `wrangler.jsonc` 中对应变量。
+
+> Cloudflare Worker 使用 Durable Object 保持一个 Arcade ticket 对应的实时世界状态。当前世界本身仍是内存状态；代码更新、Durable Object 重启或连接生命周期结束后，不保证跨实例持久化。
+
+---
+
 ## ⚙️ 可选配置 (AI 对话)
 
-默认情况下，聊天卡带使用本地回退回复规则。如需启用大语言模型对话，可在环境变量或 `.env` 中配置 OpenAI 兼容 API：
+默认情况下，聊天卡带使用本地回退回复规则。如需启用大语言模型对话，可在本地环境变量中配置 OpenAI 兼容 API：
 
 ```env
 OPENAI_API_KEY=sk-...
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4o-mini
 ```
+
+Cloudflare Workers 部署请使用上一节的 Workers Secret / Vars。
 
 ---
 
@@ -80,7 +146,7 @@ Nori.Web/
 │   ├── cartridges/           # 领域卡带层与注册中心 (Chat, CakeDuel, Chess, Codenames, Manifold, Pictionary)
 │   ├── core/                 # 核心基础设施层 (Config, Media, Protocol)
 │   ├── services/             # 领域应用服务层 (EventDispatcher, LLMService)
-│   ├── session/              # 运行时会话层 (WorldSession, WorldManager, Ticket)
+│   ├── session/              # 运行时会话层 (WorldSession, WorldManager)
 │   ├── virtual_apps/         # 虚拟应用服务 (Browser, Files, Mail, Messenger, Terminal)
 │   └── data/                 # 词库与运行时资源
 ├── docs/                     # 协议逆向与技术文档
@@ -92,8 +158,10 @@ Nori.Web/
 │   ├── test_backend_integration.py # 后端协议与 WebSocket 集成测试
 │   ├── test_client_schema.mjs# 前端 Zod 校验规则验证
 │   └── test_browser_bootstrap.mjs # 浏览器全流程引导测试
-├── server.py                 # FastAPI 入口服务
-├── requirements.txt          # Python 依赖清单
+├── server.py                 # 本地 FastAPI / Uvicorn 入口
+├── worker.py                 # Cloudflare Python Worker / Durable Object 入口
+├── wrangler.jsonc            # Cloudflare Workers 配置
+├── pyproject.toml            # Python / Worker 依赖清单
 ├── package.json              # 测试与辅助脚本配置
 └── start.bat                 # Windows 一键启动脚本
 ```
@@ -117,7 +185,7 @@ python tests/test_backend_integration.py
 # 4. 使用前端 bundle 内置的 Zod parser 校验服务端消息信封
 node tests/test_client_schema.mjs
 
-# 5. 执行完整测试套件 (需安装 Node 依赖)
+# 5. 执行完整测试套件
 npm test
 ```
 
@@ -170,4 +238,4 @@ npm test
 0. 本仓库现包含作者本人账号的世界存档快照（`backend/data/live_world_pack.json` 与 `public/webAssets/**` 下新抓取的站内静态资源），仅用于个人离线保存与研究，相关剧情文本与美术素材版权归原项目方所有；如需公开发布请自行裁剪。
 1. 本项目为独立重构的开源本地兼容实现，**不包含、不代理、也不绕过**上游私有服务端、用户数据库、私有剧情及未公开特权。
 2. 聊天卡带中的对话与角色回复依托于本地规则或用户自配的 LLM 接口，与官方云端服务无关。
-3. 本地世界状态目前按会话在内存中维护，重启服务将重置本地世界状态。
+3. 本地运行时世界状态按会话保存在内存中；Cloudflare 部署会用 Durable Object 隔离同一 ticket 的实时状态，但当前仍不提供跨重启持久化。

--- a/backend/api/arcade.py
+++ b/backend/api/arcade.py
@@ -8,7 +8,7 @@ from typing import Optional
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from ..core.protocol import error_message
-from ..session.manager import WORLD_MANAGER
+from ..session.manager import get_world_manager
 
 arcade_ws_router = APIRouter(tags=["arcade_ws"])
 
@@ -26,7 +26,7 @@ async def _accept_arcade_socket(websocket: WebSocket) -> Optional[str]:
     if "arcade.v1" not in protocols:
         await websocket.close(code=1002, reason="arcade.v1 subprotocol required")
         return None
-    user_id = await WORLD_MANAGER.resolve_ticket(ticket)
+    user_id = await get_world_manager().resolve_ticket(ticket)
     if user_id is None:
         await websocket.close(code=1008, reason="session_invalid")
         return None
@@ -36,10 +36,11 @@ async def _accept_arcade_socket(websocket: WebSocket) -> Optional[str]:
 
 @arcade_ws_router.websocket("/api/arcade/web/v1")
 async def arcade_websocket(websocket: WebSocket) -> None:
+    manager = get_world_manager()
     user_id = await _accept_arcade_socket(websocket)
     if user_id is None:
         return
-    world = await WORLD_MANAGER.get_world(user_id)
+    world = await manager.get_world(user_id)
     await world.add_client(websocket)
     try:
         while True:
@@ -53,7 +54,7 @@ async def arcade_websocket(websocket: WebSocket) -> None:
                 await world.send_direct(websocket, error_message("bad_request", "message must be an object"))
                 continue
             if message.get("type") == "reset_my_web_world":
-                new_world = await WORLD_MANAGER.reset_world(
+                new_world = await manager.reset_world(
                     user_id, message.get("locale") if isinstance(message.get("locale"), str) else None
                 )
                 await world.remove_client(websocket)
@@ -74,6 +75,7 @@ async def arcade_websocket(websocket: WebSocket) -> None:
 
 @arcade_ws_router.websocket("/api/arcade/web/v1/media")
 async def arcade_media_websocket(websocket: WebSocket) -> None:
+    manager = get_world_manager()
     user_id = await _accept_arcade_socket(websocket)
     if user_id is None:
         return
@@ -89,7 +91,7 @@ async def arcade_media_websocket(websocket: WebSocket) -> None:
         ):
             await websocket.close(code=4005, reason="media_grant_invalid")
             return
-        world = await WORLD_MANAGER.world_for_grant(user_id, message["grant"])
+        world = await manager.world_for_grant(user_id, message["grant"])
         if world is None:
             await websocket.close(code=4005, reason="media_grant_invalid")
             return

--- a/backend/api/convex.py
+++ b/backend/api/convex.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, Request
 
 from .auth import get_current_user_id
-from ..session.manager import WORLD_MANAGER
+from ..session.manager import get_world_manager
 
 convex_router = APIRouter(tags=["convex"])
 
@@ -22,7 +22,8 @@ async def _convex_local_response(request: Request) -> Dict[str, Any]:
         user_id = get_current_user_id(request)
         if not user_id:
             return {"status": "error", "errorMessage": "Unauthorized", "logLines": []}
-        return {"status": "success", "value": {"ticket": await WORLD_MANAGER.issue_ticket(user_id)}, "logLines": []}
+        ticket = await get_world_manager().issue_ticket(user_id)
+        return {"status": "success", "value": {"ticket": ticket}, "logLines": []}
     if path == "auth/otpEmail:preflightOtpSend":
         return {"status": "success", "value": None, "logLines": []}
     return {"status": "error", "errorMessage": f"Unsupported local Convex function: {path or '<missing>'}", "logLines": []}

--- a/backend/api/system.py
+++ b/backend/api/system.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Request
 from fastapi.responses import JSONResponse
 
 from .auth import get_current_user_id
-from ..session.manager import WORLD_MANAGER
+from ..session.manager import get_world_manager
 
 system_router = APIRouter(tags=["system"])
 MACHINE_ID = os.getenv("NORI_MACHINE_ID", "nori-local")
@@ -30,4 +30,4 @@ async def issue_ws_ticket(request: Request):
     user_id = get_current_user_id(request)
     if not user_id:
         return JSONResponse(status_code=401, content={"error": "Unauthorized"})
-    return {"ticket": await WORLD_MANAGER.issue_ticket(user_id)}
+    return {"ticket": await get_world_manager().issue_ticket(user_id)}

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Any
 
 # Base Paths
 CORE_DIR = Path(__file__).resolve().parent
@@ -33,3 +34,50 @@ ANTHROPIC_MODEL = os.getenv("ANTHROPIC_MODEL", "claude-3-5-sonnet-20241022")
 
 # TTS Config
 TTS_ENGINE = os.getenv("TTS_ENGINE", "built-in")  # "built-in", "openai", "edge"
+
+# Cloudflare-only behavior. The live archive is intentionally disabled by
+# default in the public Worker deployment; local mode keeps the current default.
+NORI_DISABLE_LIVE_PACK = os.getenv("NORI_DISABLE_LIVE_PACK", "")
+
+_RUNTIME_BINDINGS = (
+    "SECRET_KEY",
+    "OPENAI_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_MODEL",
+    "TTS_ENGINE",
+    "NORI_DISABLE_LIVE_PACK",
+)
+
+
+def _binding_value(env: Any, name: str) -> str | None:
+    """Read a string-like Workers binding without depending on Pyodide types."""
+    try:
+        value = getattr(env, name)
+    except Exception:
+        return None
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    try:
+        converted = value.to_py()
+    except Exception:
+        converted = value
+    return converted if isinstance(converted, str) else str(converted)
+
+
+def apply_runtime_bindings(env: Any) -> None:
+    """Overlay Cloudflare vars/secrets onto the module-level configuration.
+
+    Workers bindings are passed through the request environment rather than the
+    host process environment, so regular ``os.getenv`` calls cannot see them.
+    Local Uvicorn behavior is unchanged because this function is only invoked by
+    the Cloudflare entrypoint.
+    """
+    namespace = globals()
+    for name in _RUNTIME_BINDINGS:
+        value = _binding_value(env, name)
+        if value is not None:
+            namespace[name] = value

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -7,7 +7,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
 
-from ..core.config import OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL
+from ..core import config
 
 EMOTIONS = {
     "happy",
@@ -98,7 +98,7 @@ class LLMService:
         user_text: str,
         history: Optional[List[Dict[str, str]]] = None,
     ) -> Tuple[str, str]:
-        if OPENAI_API_KEY:
+        if config.OPENAI_API_KEY:
             try:
                 messages = [{"role": "system", "content": SYSTEM_PROMPT}]
                 if history:
@@ -107,10 +107,10 @@ class LLMService:
 
                 async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(
-                        f"{OPENAI_BASE_URL.rstrip('/')}/chat/completions",
-                        headers={"Authorization": f"Bearer {OPENAI_API_KEY}"},
+                        f"{config.OPENAI_BASE_URL.rstrip('/')}/chat/completions",
+                        headers={"Authorization": f"Bearer {config.OPENAI_API_KEY}"},
                         json={
-                            "model": OPENAI_MODEL,
+                            "model": config.OPENAI_MODEL,
                             "messages": messages,
                             "temperature": 0.75,
                             "max_tokens": 350,

--- a/backend/session/__init__.py
+++ b/backend/session/__init__.py
@@ -1,6 +1,6 @@
 """Session and world management module."""
 
-from .manager import Ticket, WORLD_MANAGER, WorldManager
+from .manager import WORLD_MANAGER, WorldManager
 from .world import WorldSession
 
-__all__ = ["Ticket", "WorldSession", "WorldManager", "WORLD_MANAGER"]
+__all__ = ["WorldSession", "WorldManager", "WORLD_MANAGER"]

--- a/backend/session/manager.py
+++ b/backend/session/manager.py
@@ -1,48 +1,80 @@
-"""World and Ticket lifecycle manager."""
+"""World and ticket lifecycle manager."""
 
 from __future__ import annotations
 
 import asyncio
+import base64
+import hashlib
+import hmac
+import json
 import secrets
 import time
-from dataclasses import dataclass
+from contextvars import ContextVar
 from typing import Dict, Optional
 
+from ..core import config
 from .world import WorldSession
 
 
-@dataclass(slots=True)
-class Ticket:
-    user_id: str
-    expires_at: float
+def _b64encode(data: bytes) -> str:
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode(value + padding)
+
+
+def _ticket_signature(payload: str) -> str:
+    digest = hmac.new(
+        config.SECRET_KEY.encode("utf-8"),
+        payload.encode("ascii"),
+        hashlib.sha256,
+    ).digest()
+    return _b64encode(digest)
 
 
 class WorldManager:
-    """Manages active user world sessions and issue/resolve arcade tickets."""
+    """Manage active user worlds and issue stateless Arcade tickets.
+
+    Tickets used to live in process memory. That works for a single local
+    Uvicorn process, but a Cloudflare HTTP request and the subsequent WebSocket
+    upgrade can land in different isolates. Signed tickets can therefore be
+    validated without shared process state.
+    """
 
     def __init__(self) -> None:
         self.worlds_by_user: Dict[str, WorldSession] = {}
-        self.tickets: Dict[str, Ticket] = {}
         self._lock = asyncio.Lock()
 
     async def issue_ticket(self, user_id: str) -> str:
-        token = secrets.token_urlsafe(32)
-        self.tickets[token] = Ticket(user_id=user_id, expires_at=time.time() + 300)
-        # Garbage collect expired tickets opportunistically
-        now = time.time()
-        for key, ticket in list(self.tickets.items()):
-            if ticket.expires_at < now:
-                self.tickets.pop(key, None)
-        return token
+        payload = {
+            "u": user_id,
+            "e": int(time.time()) + 300,
+            "n": secrets.token_urlsafe(8),
+        }
+        encoded = _b64encode(
+            json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        )
+        return f"{encoded}.{_ticket_signature(encoded)}"
 
     async def resolve_ticket(self, token: Optional[str]) -> Optional[str]:
         if not token:
             return None
-        ticket = self.tickets.get(token)
-        if ticket is None or ticket.expires_at < time.time():
-            self.tickets.pop(token, None)
+        try:
+            encoded, signature = token.rsplit(".", 1)
+            if not hmac.compare_digest(_ticket_signature(encoded), signature):
+                return None
+            payload = json.loads(_b64decode(encoded).decode("utf-8"))
+            user_id = payload.get("u")
+            expires_at = payload.get("e")
+            if not isinstance(user_id, str) or not user_id:
+                return None
+            if not isinstance(expires_at, int) or expires_at < int(time.time()):
+                return None
+            return user_id
+        except (ValueError, TypeError, json.JSONDecodeError, UnicodeDecodeError):
             return None
-        return ticket.user_id
 
     async def get_world(self, user_id: str, locale: Optional[str] = None) -> WorldSession:
         async with self._lock:
@@ -69,3 +101,21 @@ class WorldManager:
 
 
 WORLD_MANAGER = WorldManager()
+_WORLD_MANAGER_CONTEXT: ContextVar[Optional[WorldManager]] = ContextVar(
+    "nori_world_manager", default=None
+)
+
+
+def get_world_manager() -> WorldManager:
+    """Return the manager bound to the current execution context."""
+    return _WORLD_MANAGER_CONTEXT.get() or WORLD_MANAGER
+
+
+def bind_world_manager(manager: WorldManager):
+    """Bind a manager for the current ASGI task and return the ContextVar token."""
+    return _WORLD_MANAGER_CONTEXT.set(manager)
+
+
+def reset_world_manager(token) -> None:
+    """Restore the previous manager binding."""
+    _WORLD_MANAGER_CONTEXT.reset(token)

--- a/backend/virtual_apps/live_pack.py
+++ b/backend/virtual_apps/live_pack.py
@@ -24,6 +24,21 @@ _DISABLED = os.getenv("NORI_DISABLE_LIVE_PACK", "").strip().lower() in {"1", "tr
 
 _lock = threading.Lock()
 _cache: Optional[Dict[str, Any]] = None
+_PAGE_INDEX: Optional[Dict[str, Dict[str, Any]]] = None
+
+
+def set_disabled(disabled: bool) -> None:
+    """Enable or disable the archive loader at runtime.
+
+    Cloudflare Workers receive vars/secrets through request bindings rather
+    than ``os.environ``. The Worker entrypoint calls this before dispatching
+    requests so the large local archive can stay disabled in edge deployments.
+    """
+    global _DISABLED, _cache, _PAGE_INDEX
+    _DISABLED = disabled
+    if disabled:
+        _cache = None
+        _PAGE_INDEX = None
 
 
 def _pack() -> Optional[Dict[str, Any]]:
@@ -88,9 +103,6 @@ def signal_thread_artifacts() -> List[Dict[str, Any]]:
 
 def signal_message_artifacts() -> List[Dict[str, Any]]:
     return _list("signal_message_artifacts")
-
-
-_PAGE_INDEX: Optional[Dict[str, Dict[str, Any]]] = None
 
 
 def _canonical(url: str) -> str:

--- a/public/.assetsignore
+++ b/public/.assetsignore
@@ -1,0 +1,2 @@
+# Served from the private R2 binding because Workers Static Assets has a 25 MiB per-file limit.
+datasea/cosmicweb.min.glb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "nori-web"
+version = "2.0.0"
+description = "NoriOS local compatibility backend and Cloudflare Workers deployment"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+    "fastapi>=0.115",
+    "httpx>=0.27",
+    "python-chess>=1.999",
+]
+
+[project.optional-dependencies]
+local = [
+    "uvicorn[standard]>=0.30",
+    "websockets>=13",
+]
+
+[dependency-groups]
+dev = [
+    "workers-py>=1.16.2",
+    "workers-runtime-sdk>=1.6.8",
+    "uvicorn[standard]>=0.30",
+    "websockets>=13",
+]
+
+[tool.ruff]
+target-version = "py311"
+extend-exclude = ["python_modules", ".venv-workers"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-fastapi>=0.115
-uvicorn[standard]>=0.30
-httpx>=0.27
-python-chess>=1.999
-websockets>=13

--- a/server.py
+++ b/server.py
@@ -15,8 +15,13 @@ from backend.core.config import DEBUG, HOST, PORT
 register_mimetypes()
 
 
-def create_app() -> FastAPI:
-    """Create and configure the FastAPI application."""
+def create_app(*, include_static: bool = True) -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Local mode serves the frontend through FastAPI. Cloudflare Workers use
+    Workers Static Assets instead, so the Worker entrypoint disables the
+    filesystem-backed static router while keeping all HTTP/WebSocket APIs.
+    """
     application = FastAPI(title="NoriOS Local Compatibility Server", version="2.0.0")
     application.add_middleware(GZipMiddleware, minimum_size=500)
     application.add_middleware(
@@ -27,7 +32,8 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
     application.include_router(api_router)
-    application.include_router(static_router)
+    if include_static:
+        application.include_router(static_router)
     return application
 
 

--- a/start.bat
+++ b/start.bat
@@ -6,8 +6,14 @@ echo         Starting NoriOS local compatibility server
 echo =======================================================
 python --version >nul 2>&1
 if errorlevel 1 (
-    echo Python 3 is required. Install dependencies with:
-    echo   python -m pip install -r requirements.txt
+    echo Python 3 is required. Install Python first.
+    pause
+    exit /b 1
+)
+python -c "import fastapi, uvicorn, httpx, chess" >nul 2>&1
+if errorlevel 1 (
+    echo Python dependencies are missing. Install them with:
+    echo   python -m pip install -e ".[local]"
     pause
     exit /b 1
 )

--- a/tests/test_cloudflare_ticket.py
+++ b/tests/test_cloudflare_ticket.py
@@ -1,0 +1,29 @@
+"""Checks required by multi-isolate / Durable Object deployments."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from backend.session.manager import WorldManager
+
+
+async def run() -> None:
+    issuer = WorldManager()
+    resolver = WorldManager()
+
+    ticket = await issuer.issue_ticket("cloudflare-user")
+    assert await resolver.resolve_ticket(ticket) == "cloudflare-user"
+
+    payload, signature = ticket.rsplit(".", 1)
+    tampered = f"{payload}.{signature[:-1]}{'A' if signature[-1:] != 'A' else 'B'}"
+    assert await resolver.resolve_ticket(tampered) is None
+    assert await resolver.resolve_ticket(None) is None
+
+
+if __name__ == "__main__":
+    asyncio.run(run())
+    print("[ok] stateless Arcade tickets are portable across WorldManager instances")

--- a/worker.py
+++ b/worker.py
@@ -3,7 +3,8 @@
 HTTP API requests are served through Cloudflare's Python ASGI adapter. Static
 frontend files are served by Workers Static Assets. Arcade WebSocket pairs are
 routed by their signed ticket into a Durable Object so the main and media
-channels share one in-memory WorldManager.
+channels share one in-memory WorldManager. Oversized static assets are streamed
+from R2 while keeping their original public URL.
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ from __future__ import annotations
 import hashlib
 from urllib.parse import urlsplit
 
-from workers import DurableObject, WorkerEntrypoint, asgi
+from workers import DurableObject, Response, WorkerEntrypoint, asgi
 
 from backend.core import config
 from backend.session.manager import (
@@ -24,6 +25,10 @@ from server import create_app
 
 _FASTAPI_APP = create_app(include_static=False)
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+_R2_MODEL_PATH = "/datasea/cosmicweb.min.glb"
+_R2_MODEL_KEY = "datasea/cosmicweb.min.glb"
+_R2_MODEL_CONTENT_TYPE = "model/gltf-binary"
+_R2_MODEL_CACHE_CONTROL = "public, max-age=604800, immutable"
 
 
 def _configure_runtime(env) -> None:
@@ -52,6 +57,42 @@ def _ticket_from_request(request) -> str | None:
 def _durable_object_name(ticket: str | None) -> str:
     seed = ticket or "missing-ticket"
     return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _r2_headers(obj) -> dict[str, str]:
+    headers = {
+        "Content-Type": _R2_MODEL_CONTENT_TYPE,
+        "Cache-Control": _R2_MODEL_CACHE_CONTROL,
+    }
+    etag = getattr(obj, "httpEtag", None)
+    if etag:
+        headers["ETag"] = str(etag)
+    size = getattr(obj, "size", None)
+    if size is not None:
+        headers["Content-Length"] = str(size)
+    return headers
+
+
+async def _serve_r2_model(env, request):
+    """Stream the oversized DataSea GLB from the private R2 bucket."""
+    if request.method == "HEAD":
+        obj = await env.NORI_ASSETS_R2.head(_R2_MODEL_KEY)
+        if obj is None:
+            return Response("Object Not Found", status=404)
+        return Response(None, status=200, headers=_r2_headers(obj))
+
+    if request.method != "GET":
+        return Response(
+            "Method Not Allowed",
+            status=405,
+            headers={"Allow": "GET, HEAD"},
+        )
+
+    obj = await env.NORI_ASSETS_R2.get(_R2_MODEL_KEY)
+    if obj is None:
+        return Response("Object Not Found", status=404)
+
+    return Response(obj.body, status=200, headers=_r2_headers(obj))
 
 
 async def _cloudflare_asgi_app(scope, receive, send) -> None:
@@ -102,11 +143,14 @@ class NoriArcadeSession(DurableObject):
 
 
 class Default(WorkerEntrypoint):
-    """Route API traffic to FastAPI and frontend traffic to Static Assets."""
+    """Route API, R2 assets, and frontend traffic to the correct service."""
 
     async def fetch(self, request):
         _configure_runtime(self.env)
         path = urlsplit(request.url).path
+
+        if path == _R2_MODEL_PATH:
+            return await _serve_r2_model(self.env, request)
 
         if _is_websocket(request) and path.startswith("/api/arcade/web/v1"):
             ticket = _ticket_from_request(request)

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,119 @@
+"""Cloudflare Workers entrypoint for Nori.Web.
+
+HTTP API requests are served through Cloudflare's Python ASGI adapter. Static
+frontend files are served by Workers Static Assets. Arcade WebSocket pairs are
+routed by their signed ticket into a Durable Object so the main and media
+channels share one in-memory WorldManager.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from urllib.parse import urlsplit
+
+from workers import DurableObject, WorkerEntrypoint, asgi
+
+from backend.core import config
+from backend.session.manager import (
+    WorldManager,
+    bind_world_manager,
+    reset_world_manager,
+)
+from backend.virtual_apps import live_pack
+from server import create_app
+
+_FASTAPI_APP = create_app(include_static=False)
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+
+
+def _configure_runtime(env) -> None:
+    """Apply Workers vars/secrets before an ASGI request is dispatched."""
+    config.apply_runtime_bindings(env)
+    disabled = config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES
+    live_pack.set_disabled(disabled)
+
+
+def _is_websocket(request) -> bool:
+    return (request.headers.get("upgrade") or "").lower() == "websocket"
+
+
+def _requested_protocols(request) -> list[str]:
+    raw = request.headers.get("sec-websocket-protocol") or ""
+    return [item.strip() for item in raw.split(",") if item.strip()]
+
+
+def _ticket_from_request(request) -> str | None:
+    for protocol in _requested_protocols(request):
+        if protocol.startswith("ticket."):
+            return protocol[len("ticket.") :]
+    return None
+
+
+def _durable_object_name(ticket: str | None) -> str:
+    seed = ticket or "missing-ticket"
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+async def _cloudflare_asgi_app(scope, receive, send) -> None:
+    """Patch Cloudflare's WebSocket ASGI scope with requested subprotocols.
+
+    The current Workers ASGI adapter exposes the raw
+    ``Sec-WebSocket-Protocol`` header but does not populate ASGI's
+    ``scope['subprotocols']`` field. Starlette uses that field for WebSocket
+    protocol negotiation, so populate it here before FastAPI receives the
+    scope.
+    """
+    if scope.get("type") == "websocket" and not scope.get("subprotocols"):
+        protocols: list[str] = []
+        for key, value in scope.get("headers", []):
+            if key.lower() == b"sec-websocket-protocol":
+                protocols.extend(
+                    item.strip()
+                    for item in value.decode("latin-1").split(",")
+                    if item.strip()
+                )
+        scope = dict(scope)
+        scope["subprotocols"] = protocols
+    await _FASTAPI_APP(scope, receive, send)
+
+
+class NoriArcadeSession(DurableObject):
+    """Pin both Arcade WebSockets for one ticket to a single state owner."""
+
+    def __init__(self, ctx, env):
+        super().__init__(ctx, env)
+        self.manager = WorldManager()
+
+    async def fetch(self, request):
+        _configure_runtime(self.env)
+        manager_token = bind_world_manager(self.manager)
+        try:
+            if _is_websocket(request):
+                response = await asgi.websocket(_cloudflare_asgi_app, request, self.env)
+                # Workers' ASGI WebSocket adapter currently ignores the
+                # subprotocol selected by ``websocket.accept``. Echo the
+                # protocol explicitly so browsers accept the upgrade.
+                if "arcade.v1" in _requested_protocols(request):
+                    response.headers.set("Sec-WebSocket-Protocol", "arcade.v1")
+                return response
+            return await asgi.fetch(_cloudflare_asgi_app, request, self.env)
+        finally:
+            reset_world_manager(manager_token)
+
+
+class Default(WorkerEntrypoint):
+    """Route API traffic to FastAPI and frontend traffic to Static Assets."""
+
+    async def fetch(self, request):
+        _configure_runtime(self.env)
+        path = urlsplit(request.url).path
+
+        if _is_websocket(request) and path.startswith("/api/arcade/web/v1"):
+            ticket = _ticket_from_request(request)
+            stub = self.env.NORI_ARCADE.getByName(_durable_object_name(ticket))
+            return await stub.fetch(request)
+
+        if path.startswith("/api/"):
+            return await asgi.fetch(_cloudflare_asgi_app, request, self.env, self.ctx)
+
+        return await self.env.ASSETS.fetch(request)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,33 @@
+{
+  "$schema": "./node_modules/wrangler/config-schema.json",
+  "name": "nori-web",
+  "main": "worker.py",
+  "compatibility_date": "2026-08-28",
+  "compatibility_flags": ["python_workers"],
+  "assets": {
+    "directory": "./public",
+    "binding": "ASSETS",
+    "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*"]
+  },
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "NORI_ARCADE",
+        "class_name": "NoriArcadeSession"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["NoriArcadeSession"]
+    }
+  ],
+  "vars": {
+    "NORI_DISABLE_LIVE_PACK": "1"
+  },
+  "python_modules": {
+    "excludes": ["**/*.pyc", "**/__pycache__"]
+  }
+}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,8 +8,17 @@
     "directory": "./public",
     "binding": "ASSETS",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"]
+    "run_worker_first": [
+      "/api/*",
+      "/datasea/cosmicweb.min.glb"
+    ]
   },
+  "r2_buckets": [
+    {
+      "binding": "NORI_ASSETS_R2",
+      "bucket_name": "nori-web-assets"
+    }
+  ],
   "durable_objects": {
     "bindings": [
       {


### PR DESCRIPTION
## Summary

Adds first-class Cloudflare Workers deployment support while preserving the existing local `python server.py` workflow.

### Cloudflare runtime
- adds `worker.py` Python Worker entrypoint
- serves the frontend with Workers Static Assets
- routes `/api/*` through FastAPI / Cloudflare ASGI
- routes Arcade main + media WebSockets into a Durable Object keyed by signed ticket
- patches the Workers ASGI WebSocket scope with `Sec-WebSocket-Protocol` values required by the existing `arcade.v1` negotiation

### Multi-isolate state handling
- replaces process-local WebSocket tickets with HMAC-signed stateless tickets
- adds contextual `WorldManager` binding so each Durable Object owns an isolated world manager
- keeps the main and media socket for one ticket in the same Durable Object

### R2 oversized asset handling
- binds the private `nori-web-assets` R2 bucket as `NORI_ASSETS_R2`
- excludes `public/datasea/cosmicweb.min.glb` from Workers Static Assets because it exceeds the 25 MiB per-file limit
- serves the same `/datasea/cosmicweb.min.glb` URL by streaming `datasea/cosmicweb.min.glb` from R2
- provides the GLB content type and cache headers from the Worker, so the existing frontend URL does not need to change

### Configuration and packaging
- adds `wrangler.jsonc`
- migrates Python dependencies from legacy `requirements.txt` to `pyproject.toml` as required by current `pywrangler`
- supports Workers vars/secrets through runtime bindings
- disables `live_world_pack` by default in Cloudflare deployments
- updates README, Windows dependency hints, and Cloudflare build artifacts in `.gitignore`

### Validation
- adds a stateless-ticket portability test
- adds GitHub Actions validation using Python 3.13 and `pywrangler deploy --dry-run`
- current CI passes dependency sync, ticket portability, Python compilation, and a full Cloudflare bundle dry-run with the Durable Object, R2, and Static Assets bindings detected

## Deployment prerequisite

The Cloudflare account must contain an R2 bucket named `nori-web-assets` with this object already uploaded:

```text
datasea/cosmicweb.min.glb
```

The bucket can remain private; the Worker accesses it through the R2 binding and does not require a public R2 URL or access key.

## Notes

World state remains intentionally in-memory. The Durable Object keeps the paired Arcade WebSockets and their runtime state together for an active ticket, but this PR does not add durable world persistence across deployments/restarts.