### PR TITLE
fix: avoid filesystem writes during Cloudflare Worker import

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Verify stateless tickets
         run: uv run python tests/test_cloudflare_ticket.py
 
+      - name: Verify Cloudflare import safety
+        run: uv run python tests/test_cloudflare_import_safety.py
+
       - name: Compile Python sources
         run: uv run python -m compileall -q backend server.py worker.py
 

--- a/backend/core/config.py
+++ b/backend/core/config.py
@@ -12,7 +12,11 @@ BACKEND_DIR = CORE_DIR.parent
 BASE_DIR = BACKEND_DIR.parent
 PUBLIC_DIR = BASE_DIR / "public"
 DATA_DIR = BACKEND_DIR / "data"
-DATA_DIR.mkdir(parents=True, exist_ok=True)
+# Do not create directories at import time. Cloudflare Python Workers load the
+# application from a read-only metadata filesystem, so import-time filesystem
+# mutations make deployment validation fail before the Worker can start.
+# Local code that creates new files should create its writable target directory
+# at the point of use instead.
 
 # Server Config
 HOST = os.getenv("HOST", "127.0.0.1")

--- a/tests/test_cloudflare_import_safety.py
+++ b/tests/test_cloudflare_import_safety.py
@@ -1,0 +1,21 @@
+"""Regression check for Cloudflare's read-only Worker module filesystem."""
+
+from __future__ import annotations
+
+import pathlib
+
+
+_original_mkdir = pathlib.Path.mkdir
+
+
+def _blocked_mkdir(self, *args, **kwargs):
+    raise AssertionError(f"import-time mkdir is not Cloudflare-safe: {self}")
+
+
+pathlib.Path.mkdir = _blocked_mkdir
+try:
+    import backend.core.config  # noqa: F401
+finally:
+    pathlib.Path.mkdir = _original_mkdir
+
+print("[ok] backend.core.config imports without filesystem mutations")

--- a/tests/test_cloudflare_import_safety.py
+++ b/tests/test_cloudflare_import_safety.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import pathlib
+import sys
+from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
 _original_mkdir = pathlib.Path.mkdir
 


### PR DESCRIPTION
## Summary

Fixes the production Cloudflare deployment validation failure:

```text
PermissionError: [Errno 2] Permission denied: '/session/metadata/backend/data'
```

### Root cause

`backend/core/config.py` executed `DATA_DIR.mkdir(...)` at module import time. Cloudflare Python Workers import application modules from a read-only metadata filesystem, so deployment validation failed before the Worker could start.

### Changes

- removes import-time directory creation from `backend/core/config.py`
- keeps `DATA_DIR` as a path constant without mutating the filesystem
- adds `tests/test_cloudflare_import_safety.py`, which blocks `Path.mkdir` while importing the config module to guard against regressions
- runs the new import-safety test in the Cloudflare Worker CI workflow

Local behavior is unaffected because `backend/data` is already part of the repository; code that needs to create writable files should create its target directory at the point of use rather than during module import.