### PR TITLE
fix: bundle runtime word data for Cloudflare Python Worker

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -43,4 +43,14 @@ jobs:
           uv run pywrangler deploy --dry-run --outdir .worker-dist > /tmp/pywrangler.log 2>&1
           code=$?
           tail -n 120 /tmp/pywrangler.log
-          exit $code
+          if [ "$code" -ne 0 ]; then
+            exit "$code"
+          fi
+          if ! grep -Fq "backend/data/codenames_words.json" /tmp/pywrangler.log; then
+            echo "::error::Cloudflare bundle is missing backend/data/codenames_words.json"
+            exit 1
+          fi
+          if ! grep -Fq "backend/data/pictionary_words.json" /tmp/pywrangler.log; then
+            echo "::error::Cloudflare bundle is missing backend/data/pictionary_words.json"
+            exit 1
+          fi

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,17 @@
   "main": "worker.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
+  "find_additional_modules": true,
+  "rules": [
+    {
+      "type": "Text",
+      "globs": [
+        "backend/data/codenames_words.json",
+        "backend/data/pictionary_words.json"
+      ],
+      "fallthrough": true
+    }
+  ],
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary

Fixes the next production Cloudflare deployment validation failure:

```text
FileNotFoundError: /session/metadata/backend/data/codenames_words.json
```

### Root cause

The Python source modules were uploaded, but runtime JSON files under `backend/data/` were not included in the Worker module bundle. `codenames.py` reads its vocabulary during import, so Cloudflare validation failed before the Worker could start.

### Changes

- enables Wrangler additional-module discovery
- explicitly bundles only:
  - `backend/data/codenames_words.json`
  - `backend/data/pictionary_words.json`
- deliberately does **not** bundle the 11.7 MB `backend/data/live_world_pack.json` because Cloudflare deployments already run with `NORI_DISABLE_LIVE_PACK=1`
- extends CI so the Cloudflare dry-run must list both runtime word-data files in the generated Worker bundle

This keeps the existing local `Path.read_text()` behavior unchanged while making the same files available in Cloudflare's `/session/metadata` filesystem.