### PR TITLE
build: reduce Cloudflare Worker bundle for free plan

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -54,15 +54,19 @@ jobs:
             echo "::error::Cloudflare bundle is missing backend/data/pictionary_words.json"
             exit 1
           fi
-          if grep -Eq "public/.*\\.(bin|wasm)" /tmp/pywrangler.log; then
+          if grep -Eq "public/.*\.(bin|wasm)" /tmp/pywrangler.log; then
             echo "::error::Static public binary/WASM assets leaked into the Worker module bundle"
             exit 1
           fi
-          if grep -Eq "node_modules/.*\\.wasm" /tmp/pywrangler.log; then
+          if grep -Eq "node_modules/.*\.wasm" /tmp/pywrangler.log; then
             echo "::error::Node development WASM leaked into the Worker module bundle"
             exit 1
           fi
-          gzip_kib=$(grep -oE 'gzip: [0-9]+(\\.[0-9]+)? KiB' /tmp/pywrangler.log | tail -n 1 | awk '{print $2}')
+          if grep -Eq '│ (tests/|scraper/|\.venv[^/]*/)' /tmp/pywrangler.log; then
+            echo "::error::Development Python files leaked into the Worker module bundle"
+            exit 1
+          fi
+          gzip_kib=$(sed -n 's/.*gzip: \([0-9.]*\) KiB.*/\1/p' /tmp/pywrangler.log | tail -n 1)
           if [ -z "$gzip_kib" ]; then
             echo "::error::Unable to determine Cloudflare Worker gzip size"
             exit 1

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -54,3 +54,21 @@ jobs:
             echo "::error::Cloudflare bundle is missing backend/data/pictionary_words.json"
             exit 1
           fi
+          if grep -Eq "public/.*\\.(bin|wasm)" /tmp/pywrangler.log; then
+            echo "::error::Static public binary/WASM assets leaked into the Worker module bundle"
+            exit 1
+          fi
+          if grep -Eq "node_modules/.*\\.wasm" /tmp/pywrangler.log; then
+            echo "::error::Node development WASM leaked into the Worker module bundle"
+            exit 1
+          fi
+          gzip_kib=$(grep -oE 'gzip: [0-9]+(\\.[0-9]+)? KiB' /tmp/pywrangler.log | tail -n 1 | awk '{print $2}')
+          if [ -z "$gzip_kib" ]; then
+            echo "::error::Unable to determine Cloudflare Worker gzip size"
+            exit 1
+          fi
+          echo "Cloudflare Worker gzip size: ${gzip_kib} KiB"
+          awk -v size="$gzip_kib" 'BEGIN { if (size >= 3072) exit 1 }' || {
+            echo "::error::Cloudflare Worker gzip bundle must stay below the Free-plan 3 MiB limit (3072 KiB)"
+            exit 1
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ data/*.db
 python_modules/
 .wrangler/
 .dev.vars
+cloudflare/worker_runtime.py
+cloudflare/server.py
+cloudflare/backend/
 
 # --- scraper secrets & archive ---
 .scraper_token.txt

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -1,0 +1,11 @@
+"""Stable Cloudflare Worker entrypoint.
+
+Wrangler's build hook populates this directory with the current Nori.Web
+runtime before each dev/deploy invocation. Keeping the module root isolated
+prevents tests, scraper tools, frontend binaries, and local virtual
+environments from being counted against the Worker script-size limit.
+"""
+
+from worker_runtime import Default, NoriArcadeSession
+
+__all__ = ["Default", "NoriArcadeSession"]

--- a/scripts/prepare_cloudflare_runtime.py
+++ b/scripts/prepare_cloudflare_runtime.py
@@ -1,0 +1,56 @@
+"""Build the minimal source tree uploaded as the Cloudflare Python Worker.
+
+The repository also contains tests, scraper tooling, frontend assets and local
+virtual environments. Wrangler's Python module discovery must not see those
+files because they count against the Worker script-size limit. This script is
+run automatically by Wrangler's build hook before dev/deploy.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+STAGE = ROOT / "cloudflare"
+BACKEND_SOURCE = ROOT / "backend"
+BACKEND_TARGET = STAGE / "backend"
+
+RUNTIME_DATA_FILES = (
+    Path("data/codenames_words.json"),
+    Path("data/pictionary_words.json"),
+)
+
+
+def _copy_file(source: Path, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, target)
+
+
+def main() -> None:
+    # Only generated content is removed. cloudflare/entry.py is tracked and is
+    # intentionally left in place as Wrangler's stable entrypoint.
+    for generated in (STAGE / "worker_runtime.py", STAGE / "server.py"):
+        generated.unlink(missing_ok=True)
+    if BACKEND_TARGET.exists():
+        shutil.rmtree(BACKEND_TARGET)
+
+    _copy_file(ROOT / "worker.py", STAGE / "worker_runtime.py")
+    _copy_file(ROOT / "server.py", STAGE / "server.py")
+
+    for source in BACKEND_SOURCE.rglob("*.py"):
+        relative = source.relative_to(BACKEND_SOURCE)
+        _copy_file(source, BACKEND_TARGET / relative)
+
+    for relative in RUNTIME_DATA_FILES:
+        _copy_file(BACKEND_SOURCE / relative, BACKEND_TARGET / relative)
+
+    python_files = sum(1 for _ in BACKEND_TARGET.rglob("*.py"))
+    print(
+        "Prepared Cloudflare runtime: "
+        f"{python_files} backend Python files + {len(RUNTIME_DATA_FILES)} data files"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,13 +4,14 @@
   "main": "worker.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
+  "base_dir": "./backend",
   "find_additional_modules": true,
   "rules": [
     {
       "type": "Text",
       "globs": [
-        "backend/data/codenames_words.json",
-        "backend/data/pictionary_words.json"
+        "data/codenames_words.json",
+        "data/pictionary_words.json"
       ],
       "fallthrough": true
     }

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,19 +1,12 @@
 {
   "$schema": "./node_modules/wrangler/config-schema.json",
   "name": "nori-web",
-  "main": "worker.py",
+  "main": "cloudflare/entry.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
+  "base_dir": "./cloudflare",
   "find_additional_modules": true,
   "rules": [
-    {
-      "type": "PythonModule",
-      "globs": [
-        "backend/**/*.py",
-        "server.py"
-      ],
-      "fallthrough": false
-    },
     {
       "type": "Text",
       "globs": [
@@ -33,6 +26,10 @@
       "fallthrough": false
     }
   ],
+  "build": {
+    "command": "uv run python scripts/prepare_cloudflare_runtime.py",
+    "cwd": "."
+  },
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -7,6 +7,14 @@
   "find_additional_modules": true,
   "rules": [
     {
+      "type": "PythonModule",
+      "globs": [
+        "backend/**/*.py",
+        "server.py"
+      ],
+      "fallthrough": false
+    },
+    {
       "type": "Text",
       "globs": [
         "backend/data/codenames_words.json",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,16 +4,25 @@
   "main": "worker.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
-  "base_dir": "./backend",
   "find_additional_modules": true,
   "rules": [
     {
       "type": "Text",
       "globs": [
-        "data/codenames_words.json",
-        "data/pictionary_words.json"
+        "backend/data/codenames_words.json",
+        "backend/data/pictionary_words.json"
       ],
-      "fallthrough": true
+      "fallthrough": false
+    },
+    {
+      "type": "Data",
+      "globs": ["__nori_no_data_modules__"],
+      "fallthrough": false
+    },
+    {
+      "type": "CompiledWasm",
+      "globs": ["__nori_no_wasm_modules__"],
+      "fallthrough": false
     }
   ],
   "assets": {


### PR DESCRIPTION
## Summary

Fixes the Cloudflare Free-plan 3 MiB Worker size failure without requiring a paid Workers plan.

### Root cause

Python Worker module discovery was running from the repository root. That caused unrelated repository content to be attached to the Worker script bundle, including frontend binary/WASM assets, development tooling, tests, scraper code, and local Python environments. The production upload reached about **10.86 MiB gzip**, far above the Free-plan 3 MiB limit.

### Final approach

- adds a tracked, minimal `cloudflare/entry.py`
- adds `scripts/prepare_cloudflare_runtime.py`
- uses Wrangler's custom build hook to automatically stage the current runtime before every `dev` / `deploy`
- stages only:
  - current `worker.py`
  - current `server.py`
  - `backend/**/*.py`
  - `backend/data/codenames_words.json`
  - `backend/data/pictionary_words.json`
- deliberately excludes `live_world_pack.json`, tests, scraper tooling, frontend binaries, Node dependencies, and virtual environments
- points Wrangler `base_dir` at the isolated generated runtime while preserving the `backend.*` Python package paths
- keeps generated staging files out of Git

No duplicate backend implementation is maintained: the staging tree is regenerated from the current source by Wrangler automatically, so deployment remains:

```bash
uv run pywrangler deploy
```

### Validation

Latest CI is fully green and verifies:

- stateless Arcade ticket behavior
- Cloudflare import safety
- Python source compilation
- required Codenames/Pictionary data files are present
- public binary/WASM assets do not leak into the Worker script
- Node development WASM does not leak into the Worker script
- tests, scraper code, and virtual environments do not leak into the Worker script
- compressed Worker bundle remains below the Free-plan 3 MiB limit

Latest Cloudflare dry-run result:

```text
Total Upload: 9619.62 KiB / gzip: 2424.66 KiB
Cloudflare Worker gzip size: 2424.66 KiB
```

This leaves roughly 647 KiB of compressed headroom below 3072 KiB while retaining FastAPI, Pydantic, `python-chess`, Durable Objects, R2, and Workers Static Assets.