### PR TITLE
feat: load full live-world archive from R2

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Verify Cloudflare import safety
         run: uv run python tests/test_cloudflare_import_safety.py
 
+      - name: Verify runtime live pack injection
+        run: uv run python tests/test_live_pack_runtime.py
+
       - name: Compile Python sources
         run: uv run python -m compileall -q backend server.py worker.py
 
@@ -52,6 +55,10 @@ jobs:
           fi
           if ! grep -Fq "backend/data/pictionary_words.json" /tmp/pywrangler.log; then
             echo "::error::Cloudflare bundle is missing backend/data/pictionary_words.json"
+            exit 1
+          fi
+          if grep -Fq "backend/data/live_world_pack.json" /tmp/pywrangler.log; then
+            echo "::error::The large live-world archive leaked into the Worker bundle instead of R2"
             exit 1
           fi
           if grep -Eq "public/.*\.(bin|wasm)" /tmp/pywrangler.log; then

--- a/backend/virtual_apps/live_pack.py
+++ b/backend/virtual_apps/live_pack.py
@@ -5,6 +5,10 @@ the production NoriOS world. When present, the backend replays the user's
 real mail / files / Signal threads / browser sites / story facts instead of
 the built-in mock data. Every accessor returns deep copies so handlers can
 mutate freely without corrupting the shared cache.
+
+Local deployments can load the JSON from disk. Cloudflare Workers inject the
+same decoded pack from a private R2 binding so the large archive does not count
+toward the Worker script-size limit.
 """
 
 from __future__ import annotations
@@ -31,14 +35,36 @@ def set_disabled(disabled: bool) -> None:
     """Enable or disable the archive loader at runtime.
 
     Cloudflare Workers receive vars/secrets through request bindings rather
-    than ``os.environ``. The Worker entrypoint calls this before dispatching
-    requests so the large local archive can stay disabled in edge deployments.
+    than ``os.environ``. Disabling also drops an already-loaded R2 pack so the
+    setting takes effect immediately.
     """
     global _DISABLED, _cache, _PAGE_INDEX
     _DISABLED = disabled
     if disabled:
         _cache = None
         _PAGE_INDEX = None
+
+
+def install_pack(data: Dict[str, Any]) -> bool:
+    """Install an already-decoded archive into the process/isolate cache.
+
+    This is used by Cloudflare Workers after retrieving the archive from R2.
+    The object is treated as immutable; public accessors still return deep
+    copies exactly as they do for the local on-disk pack.
+    """
+    if not isinstance(data, dict):
+        return False
+    global _DISABLED, _cache, _PAGE_INDEX
+    with _lock:
+        _cache = data
+        _PAGE_INDEX = None
+        _DISABLED = False
+    return True
+
+
+def has_loaded_pack() -> bool:
+    """Return whether an archive is already resident in the runtime cache."""
+    return not _DISABLED and _cache is not None
 
 
 def _pack() -> Optional[Dict[str, Any]]:

--- a/docs/CLOUDFLARE_LIVE_PACK.md
+++ b/docs/CLOUDFLARE_LIVE_PACK.md
@@ -1,0 +1,38 @@
+# Cloudflare live-world archive
+
+Cloudflare Workers must not bundle `backend/data/live_world_pack.json` into the Worker script because the archive is large and would exceed the Free-plan script-size limit.
+
+The Worker reads the archive privately from the existing `NORI_ASSETS_R2` binding instead.
+
+## Upload the archive
+
+The configured bucket is `nori-web-assets` and the required object key is:
+
+```text
+runtime/live_world_pack.json
+```
+
+Upload the repository copy with Wrangler:
+
+```bash
+uv run pywrangler r2 object put nori-web-assets/runtime/live_world_pack.json \
+  --file=backend/data/live_world_pack.json \
+  --content-type=application/json \
+  --remote
+```
+
+On PowerShell, the same command can be entered on one line:
+
+```powershell
+uv run pywrangler r2 object put nori-web-assets/runtime/live_world_pack.json --file=backend/data/live_world_pack.json --content-type=application/json --remote
+```
+
+Then deploy normally:
+
+```bash
+uv run pywrangler deploy
+```
+
+`NORI_DISABLE_LIVE_PACK` defaults to `0` for the Cloudflare deployment. Set it to `1` only when you explicitly want mock/demo data.
+
+At runtime, each Worker isolate loads the archive from R2 on first use and keeps the decoded data in memory for subsequent requests. If the R2 object is missing or invalid, the service stays available and falls back to mock data while logging the reason.

--- a/tests/test_live_pack_runtime.py
+++ b/tests/test_live_pack_runtime.py
@@ -1,0 +1,48 @@
+from backend.virtual_apps import live_pack
+
+
+def main() -> None:
+    sample = {
+        "world_id": "test-world",
+        "mail_artifacts": [{"id": "mail-1", "subject": "hello"}],
+        "file_artifacts": [{"id": "file-1", "name": "note.txt"}],
+        "signal_thread_artifacts": [{"id": "thread-1"}],
+        "signal_message_artifacts": [{"id": "message-1", "thread_id": "thread-1"}],
+        "browser_pages": [
+            {
+                "key": "https://example.test/page?q=1",
+                "aliases": ["http://example.test/page?q=1"],
+                "data": {"url": "https://example.test/page?q=1", "title": "Example"},
+            }
+        ],
+        "facts": {"chapter": 7},
+        "variables": {"flag": True},
+        "chip_status": {"online": True},
+    }
+
+    live_pack.set_disabled(False)
+    assert live_pack.install_pack(sample)
+    assert live_pack.has_loaded_pack()
+    assert live_pack.is_available()
+    assert live_pack.mail_artifacts()[0]["id"] == "mail-1"
+    assert live_pack.file_artifacts()[0]["id"] == "file-1"
+    assert live_pack.signal_thread_artifacts()[0]["id"] == "thread-1"
+    assert live_pack.signal_message_artifacts()[0]["id"] == "message-1"
+    assert live_pack.page("https://example.test/page?q=1")["data"]["title"] == "Example"
+    assert live_pack.page("http://example.test/page?q=1")["data"]["title"] == "Example"
+    assert live_pack.facts()["chapter"] == 7
+    assert live_pack.variables()["flag"] is True
+    assert live_pack.chip_status()["online"] is True
+
+    copied = live_pack.mail_artifacts()
+    copied[0]["subject"] = "mutated"
+    assert live_pack.mail_artifacts()[0]["subject"] == "hello"
+
+    live_pack.set_disabled(True)
+    assert not live_pack.has_loaded_pack()
+    assert live_pack.mail_artifacts() == []
+    print("[ok] runtime live-world pack injection is available to existing accessors")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_live_pack_runtime.py
+++ b/tests/test_live_pack_runtime.py
@@ -1,3 +1,10 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
 from backend.virtual_apps import live_pack
 
 

--- a/worker.py
+++ b/worker.py
@@ -3,13 +3,17 @@
 HTTP API requests are served through Cloudflare's Python ASGI adapter. Static
 frontend files are served by Workers Static Assets. Arcade WebSocket pairs are
 routed by their signed ticket into a Durable Object so the main and media
-channels share one in-memory WorldManager. Oversized static assets are streamed
-from R2 while keeping their original public URL.
+channels share one in-memory WorldManager. Oversized static assets and the
+private live-world archive are read from R2 so they do not consume Worker
+script-size quota.
 """
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
+import json
+import time
 from urllib.parse import urlsplit
 
 from workers import DurableObject, Response, WorkerEntrypoint, asgi
@@ -29,13 +33,57 @@ _R2_MODEL_PATH = "/datasea/cosmicweb.min.glb"
 _R2_MODEL_KEY = "datasea/cosmicweb.min.glb"
 _R2_MODEL_CONTENT_TYPE = "model/gltf-binary"
 _R2_MODEL_CACHE_CONTROL = "public, max-age=604800, immutable"
+_R2_LIVE_PACK_KEY = "runtime/live_world_pack.json"
+_LIVE_PACK_LOAD_LOCK = asyncio.Lock()
+_LIVE_PACK_RETRY_SECONDS = 60.0
+_live_pack_retry_at = 0.0
 
 
-def _configure_runtime(env) -> None:
-    """Apply Workers vars/secrets before an ASGI request is dispatched."""
+async def _configure_runtime(env) -> None:
+    """Apply runtime bindings and make the private live archive available."""
+    global _live_pack_retry_at
+
     config.apply_runtime_bindings(env)
     disabled = config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES
     live_pack.set_disabled(disabled)
+    if disabled or live_pack.has_loaded_pack():
+        return
+
+    now = time.monotonic()
+    if now < _live_pack_retry_at:
+        return
+
+    async with _LIVE_PACK_LOAD_LOCK:
+        if live_pack.has_loaded_pack():
+            return
+
+        now = time.monotonic()
+        if now < _live_pack_retry_at:
+            return
+
+        try:
+            obj = await env.NORI_ASSETS_R2.get(_R2_LIVE_PACK_KEY)
+            if obj is None:
+                print(
+                    f"[live_pack] R2 object missing: {_R2_LIVE_PACK_KEY}; "
+                    "falling back to mock data"
+                )
+                _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
+                return
+
+            raw = await obj.text()
+            data = json.loads(raw)
+            del raw
+            if not live_pack.install_pack(data):
+                print("[live_pack] R2 archive root is not a JSON object; using mock data")
+                _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
+                return
+
+            _live_pack_retry_at = 0.0
+            print(f"[live_pack] loaded from R2: {live_pack.summary()}")
+        except Exception as exc:
+            print(f"[live_pack] failed to load R2 archive: {exc}")
+            _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
 
 
 def _is_websocket(request) -> bool:
@@ -126,7 +174,7 @@ class NoriArcadeSession(DurableObject):
         self.manager = WorldManager()
 
     async def fetch(self, request):
-        _configure_runtime(self.env)
+        await _configure_runtime(self.env)
         manager_token = bind_world_manager(self.manager)
         try:
             if _is_websocket(request):
@@ -146,7 +194,7 @@ class Default(WorkerEntrypoint):
     """Route API, R2 assets, and frontend traffic to the correct service."""
 
     async def fetch(self, request):
-        _configure_runtime(self.env)
+        await _configure_runtime(self.env)
         path = urlsplit(request.url).path
 
         if path == _R2_MODEL_PATH:

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -60,7 +60,7 @@
     }
   ],
   "vars": {
-    "NORI_DISABLE_LIVE_PACK": "1"
+    "NORI_DISABLE_LIVE_PACK": "0"
   },
   "python_modules": {
     "excludes": ["**/*.pyc", "**/__pycache__"]


### PR DESCRIPTION
## Summary

Restores the complete live NoriOS world data on Cloudflare Workers without putting the 11.7 MB `live_world_pack.json` back into the Worker script bundle.

### Root cause

The Free-plan bundle-size fix intentionally excluded `backend/data/live_world_pack.json` and left `NORI_DISABLE_LIVE_PACK=1`, so Cloudflare deployments could start successfully but Mail, Files, Signal, Browser pages, facts, variables, and chip state fell back to mock/incomplete data.

### Fix

- adds runtime archive injection support to `backend.virtual_apps.live_pack`
- loads `runtime/live_world_pack.json` privately from the existing `NORI_ASSETS_R2` bucket binding on first use per Worker isolate
- caches the decoded archive in memory for subsequent requests
- keeps local filesystem loading unchanged
- changes Cloudflare default `NORI_DISABLE_LIVE_PACK` to `0`
- retries R2 lookup after a short delay if the object is missing or temporarily unavailable
- keeps the service available with mock fallback when the R2 object cannot be loaded
- adds a runtime-injection test and CI guard ensuring the 11.7 MB JSON never leaks back into the Worker bundle
- documents the exact R2 upload command in `docs/CLOUDFLARE_LIVE_PACK.md`

### Required deployment data

Upload the repository archive to the existing bucket before/after deploying this PR:

```powershell
uv run pywrangler r2 object put nori-web-assets/runtime/live_world_pack.json --file=backend/data/live_world_pack.json --content-type=application/json --remote
```

Then deploy normally:

```powershell
uv run pywrangler deploy
```
