### PR TITLE
fix: avoid blocking Arcade WebSocket handshake on R2 world load

### DIFF
--- a/backend/api/arcade.py
+++ b/backend/api/arcade.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 
 from ..core.protocol import error_message
 from ..session.manager import get_world_manager
+from ..virtual_apps import live_pack
 
 arcade_ws_router = APIRouter(tags=["arcade_ws"])
 
@@ -40,6 +41,14 @@ async def arcade_websocket(websocket: WebSocket) -> None:
     user_id = await _accept_arcade_socket(websocket)
     if user_id is None:
         return
+
+    # The socket is deliberately accepted before a cold Cloudflare Durable
+    # Object downloads/decodes the large R2 live-world archive. This keeps the
+    # browser's WebSocket upgrade from timing out while still guaranteeing that
+    # the archive is ready before WorldSession builds its default cartridges.
+    if not await live_pack.ensure_runtime_pack():
+        print("[arcade] live-world archive unavailable; continuing with mock data")
+
     world = await manager.get_world(user_id)
     await world.add_client(websocket)
     try:

--- a/backend/virtual_apps/live_pack.py
+++ b/backend/virtual_apps/live_pack.py
@@ -18,8 +18,9 @@ import json
 import os
 import re
 import threading
+from contextvars import ContextVar
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Awaitable, Callable, Dict, List, Optional
 from urllib.parse import urlsplit
 
 PACK_PATH = Path(__file__).resolve().parents[1] / "data" / "live_world_pack.json"
@@ -29,6 +30,10 @@ _DISABLED = os.getenv("NORI_DISABLE_LIVE_PACK", "").strip().lower() in {"1", "tr
 _lock = threading.Lock()
 _cache: Optional[Dict[str, Any]] = None
 _PAGE_INDEX: Optional[Dict[str, Dict[str, Any]]] = None
+RuntimePackLoader = Callable[[], Awaitable[bool]]
+_RUNTIME_PACK_LOADER: ContextVar[Optional[RuntimePackLoader]] = ContextVar(
+    "nori_runtime_pack_loader", default=None
+)
 
 
 def set_disabled(disabled: bool) -> None:
@@ -65,6 +70,40 @@ def install_pack(data: Dict[str, Any]) -> bool:
 def has_loaded_pack() -> bool:
     """Return whether an archive is already resident in the runtime cache."""
     return not _DISABLED and _cache is not None
+
+
+def bind_runtime_loader(loader: RuntimePackLoader):
+    """Bind an async runtime loader for the current execution context."""
+    return _RUNTIME_PACK_LOADER.set(loader)
+
+
+def reset_runtime_loader(token) -> None:
+    """Restore the previous runtime-pack loader binding."""
+    _RUNTIME_PACK_LOADER.reset(token)
+
+
+async def ensure_runtime_pack() -> bool:
+    """Ensure the live archive is ready before a world is constructed.
+
+    Local execution falls back to the on-disk JSON. Cloudflare binds an async
+    R2 loader around the ASGI task so WebSocket handlers can accept the socket
+    first, then await the large archive without delaying the HTTP 101 upgrade.
+    """
+    if _DISABLED:
+        return False
+    if has_loaded_pack():
+        return True
+
+    loader = _RUNTIME_PACK_LOADER.get()
+    if loader is not None:
+        try:
+            await loader()
+        except Exception as exc:
+            print(f"[live_pack] runtime loader failed: {exc}")
+        if has_loaded_pack():
+            return True
+
+    return _pack() is not None
 
 
 def _pack() -> Optional[Dict[str, Any]]:

--- a/tests/test_live_pack_runtime.py
+++ b/tests/test_live_pack_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
 
@@ -8,8 +9,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from backend.virtual_apps import live_pack
 
 
-def main() -> None:
-    sample = {
+def _sample() -> dict:
+    return {
         "world_id": "test-world",
         "mail_artifacts": [{"id": "mail-1", "subject": "hello"}],
         "file_artifacts": [{"id": "file-1", "name": "note.txt"}],
@@ -27,8 +28,8 @@ def main() -> None:
         "chip_status": {"online": True},
     }
 
-    live_pack.set_disabled(False)
-    assert live_pack.install_pack(sample)
+
+def _assert_accessors() -> None:
     assert live_pack.has_loaded_pack()
     assert live_pack.is_available()
     assert live_pack.mail_artifacts()[0]["id"] == "mail-1"
@@ -45,11 +46,42 @@ def main() -> None:
     copied[0]["subject"] = "mutated"
     assert live_pack.mail_artifacts()[0]["subject"] == "hello"
 
+
+async def main() -> None:
+    # Existing direct injection path remains valid.
+    live_pack.set_disabled(False)
+    assert live_pack.install_pack(_sample())
+    _assert_accessors()
+
+    # Cloudflare binds a loader before dispatching the ASGI WebSocket task,
+    # but simply binding it must not trigger any I/O. The load happens only
+    # when the accepted Arcade handler explicitly calls ensure_runtime_pack().
+    live_pack.set_disabled(True)
+    live_pack.set_disabled(False)
+    calls: list[str] = []
+
+    async def deferred_loader() -> bool:
+        calls.append("load")
+        return live_pack.install_pack(_sample())
+
+    token = live_pack.bind_runtime_loader(deferred_loader)
+    try:
+        assert calls == []
+        assert not live_pack.has_loaded_pack()
+        assert await live_pack.ensure_runtime_pack()
+        assert calls == ["load"]
+        _assert_accessors()
+        # Once resident, subsequent world opens do not re-fetch R2.
+        assert await live_pack.ensure_runtime_pack()
+        assert calls == ["load"]
+    finally:
+        live_pack.reset_runtime_loader(token)
+
     live_pack.set_disabled(True)
     assert not live_pack.has_loaded_pack()
     assert live_pack.mail_artifacts() == []
-    print("[ok] runtime live-world pack injection is available to existing accessors")
+    print("[ok] runtime live-world pack loading is deferred until explicitly ensured")
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())

--- a/worker.py
+++ b/worker.py
@@ -39,27 +39,39 @@ _LIVE_PACK_RETRY_SECONDS = 60.0
 _live_pack_retry_at = 0.0
 
 
-async def _configure_runtime(env) -> None:
-    """Apply runtime bindings and make the private live archive available."""
-    global _live_pack_retry_at
-
+def _apply_runtime_bindings(env) -> None:
+    """Apply Workers vars/secrets without doing any blocking R2 I/O."""
     config.apply_runtime_bindings(env)
     disabled = config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES
     live_pack.set_disabled(disabled)
-    if disabled or live_pack.has_loaded_pack():
-        return
+
+
+async def _load_live_pack_from_r2(env) -> bool:
+    """Load the private live archive into the current Worker/DO isolate.
+
+    This function is intentionally invoked from the Arcade ASGI handler only
+    after ``websocket.accept()``. Keeping the 11.7 MB R2 download and JSON
+    decode off the HTTP upgrade path prevents browsers from timing out while a
+    cold Durable Object initializes.
+    """
+    global _live_pack_retry_at
+
+    if config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES:
+        return False
+    if live_pack.has_loaded_pack():
+        return True
 
     now = time.monotonic()
     if now < _live_pack_retry_at:
-        return
+        return False
 
     async with _LIVE_PACK_LOAD_LOCK:
         if live_pack.has_loaded_pack():
-            return
+            return True
 
         now = time.monotonic()
         if now < _live_pack_retry_at:
-            return
+            return False
 
         try:
             obj = await env.NORI_ASSETS_R2.get(_R2_LIVE_PACK_KEY)
@@ -69,7 +81,7 @@ async def _configure_runtime(env) -> None:
                     "falling back to mock data"
                 )
                 _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
-                return
+                return False
 
             raw = await obj.text()
             data = json.loads(raw)
@@ -77,13 +89,15 @@ async def _configure_runtime(env) -> None:
             if not live_pack.install_pack(data):
                 print("[live_pack] R2 archive root is not a JSON object; using mock data")
                 _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
-                return
+                return False
 
             _live_pack_retry_at = 0.0
             print(f"[live_pack] loaded from R2: {live_pack.summary()}")
+            return True
         except Exception as exc:
             print(f"[live_pack] failed to load R2 archive: {exc}")
             _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
+            return False
 
 
 def _is_websocket(request) -> bool:
@@ -174,8 +188,11 @@ class NoriArcadeSession(DurableObject):
         self.manager = WorldManager()
 
     async def fetch(self, request):
-        await _configure_runtime(self.env)
+        _apply_runtime_bindings(self.env)
         manager_token = bind_world_manager(self.manager)
+        loader_token = live_pack.bind_runtime_loader(
+            lambda: _load_live_pack_from_r2(self.env)
+        )
         try:
             if _is_websocket(request):
                 response = await asgi.websocket(_cloudflare_asgi_app, request, self.env)
@@ -187,6 +204,7 @@ class NoriArcadeSession(DurableObject):
                 return response
             return await asgi.fetch(_cloudflare_asgi_app, request, self.env)
         finally:
+            live_pack.reset_runtime_loader(loader_token)
             reset_world_manager(manager_token)
 
 
@@ -194,7 +212,10 @@ class Default(WorkerEntrypoint):
     """Route API, R2 assets, and frontend traffic to the correct service."""
 
     async def fetch(self, request):
-        await _configure_runtime(self.env)
+        # Authentication, entry-status and ticket issuance must stay fast.
+        # Do not fetch/decode the live archive in the ordinary Worker isolate;
+        # the Durable Object loads it after the WebSocket has been accepted.
+        _apply_runtime_bindings(self.env)
         path = urlsplit(request.url).path
 
         if path == _R2_MODEL_PATH:


### PR DESCRIPTION
## Summary

Fixes the Cloudflare deployment reaching the static frontend but falling into the client `连接失败` screen when entering NoriOS.

### Root cause

After restoring the 11.7 MB live-world archive from R2, the Worker awaited the R2 download + JSON decode at the very start of every API request and again inside the Durable Object. On a cold Arcade connection this put the large archive load directly in front of the WebSocket HTTP 101 upgrade, so the browser could time out before the socket was accepted.

### Fix

- separates fast runtime-binding setup from large R2 archive loading
- keeps `/api/entry-status`, auth, Convex ticket issuance, and `/api/arcade/ws-ticket` free of live-pack R2 I/O
- binds the Cloudflare R2 archive loader into the Durable Object ASGI task through a `ContextVar`
- accepts `arcade.v1` first, then loads/decodes the live archive before constructing `WorldSession`
- preserves local on-disk live-pack behavior
- caches the decoded R2 archive per Durable Object isolate as before
- adds a regression test proving that binding a runtime loader does not perform I/O until `ensure_runtime_pack()` is explicitly awaited, and that it is only invoked once after the pack becomes resident

This keeps the complete Mail / Files / Signal / Browser / facts dataset while removing the large R2 fetch from the WebSocket upgrade critical path.