### PR TITLE
fix: shard Cloudflare live-world data to avoid DO resets

### DIFF
--- a/backend/virtual_apps/live_pack.py
+++ b/backend/virtual_apps/live_pack.py
@@ -1,14 +1,10 @@
 """Loader for the optional live-world archive pack (`live_world_pack.json`).
 
 The pack is produced by `scraper/import_pack.py` from a read-only scrape of
-the production NoriOS world. When present, the backend replays the user's
-real mail / files / Signal threads / browser sites / story facts instead of
-the built-in mock data. Every accessor returns deep copies so handlers can
-mutate freely without corrupting the shared cache.
-
-Local deployments can load the JSON from disk. Cloudflare Workers inject the
-same decoded pack from a private R2 binding so the large archive does not count
-toward the Worker script-size limit.
+the production NoriOS world. Local deployments can read the complete JSON from
+disk. Cloudflare installs a small core snapshot first and attaches artifact
+sections on demand from private R2 objects so the Python Durable Object stays
+well below the 128 MiB isolate memory limit.
 """
 
 from __future__ import annotations
@@ -24,25 +20,33 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from urllib.parse import urlsplit
 
 PACK_PATH = Path(__file__).resolve().parents[1] / "data" / "live_world_pack.json"
-# NORI_DISABLE_LIVE_PACK=1 → ignore the archive entirely (mock-data mode).
-_DISABLED = os.getenv("NORI_DISABLE_LIVE_PACK", "").strip().lower() in {"1", "true", "yes", "on"}
+_DISABLED = os.getenv("NORI_DISABLE_LIVE_PACK", "").strip().lower() in {
+    "1",
+    "true",
+    "yes",
+    "on",
+}
 
 _lock = threading.Lock()
 _cache: Optional[Dict[str, Any]] = None
 _PAGE_INDEX: Optional[Dict[str, Dict[str, Any]]] = None
+
 RuntimePackLoader = Callable[[], Awaitable[bool]]
 _RUNTIME_PACK_LOADER: ContextVar[Optional[RuntimePackLoader]] = ContextVar(
     "nori_runtime_pack_loader", default=None
 )
 
+_SECTION_KEYS = {
+    "mail_artifacts",
+    "file_artifacts",
+    "signal_thread_artifacts",
+    "signal_message_artifacts",
+    "browser_pages",
+}
+
 
 def set_disabled(disabled: bool) -> None:
-    """Enable or disable the archive loader at runtime.
-
-    Cloudflare Workers receive vars/secrets through request bindings rather
-    than ``os.environ``. Disabling also drops an already-loaded R2 pack so the
-    setting takes effect immediately.
-    """
+    """Enable or disable archive replay at runtime."""
     global _DISABLED, _cache, _PAGE_INDEX
     _DISABLED = disabled
     if disabled:
@@ -51,12 +55,7 @@ def set_disabled(disabled: bool) -> None:
 
 
 def install_pack(data: Dict[str, Any]) -> bool:
-    """Install an already-decoded archive into the process/isolate cache.
-
-    This is used by Cloudflare Workers after retrieving the archive from R2.
-    The object is treated as immutable; public accessors still return deep
-    copies exactly as they do for the local on-disk pack.
-    """
+    """Install a complete already-decoded archive."""
     if not isinstance(data, dict):
         return False
     global _DISABLED, _cache, _PAGE_INDEX
@@ -67,28 +66,62 @@ def install_pack(data: Dict[str, Any]) -> bool:
     return True
 
 
+def install_core(data: Dict[str, Any]) -> bool:
+    """Install the lightweight archive core while keeping heavy sections lazy."""
+    if not isinstance(data, dict):
+        return False
+    global _DISABLED, _cache, _PAGE_INDEX
+    with _lock:
+        core = {key: value for key, value in data.items() if key not in _SECTION_KEYS}
+        _cache = core
+        _PAGE_INDEX = None
+        _DISABLED = False
+    return True
+
+
+def install_section(key: str, value: Any) -> bool:
+    """Install one artifact section fetched from R2."""
+    if key not in _SECTION_KEYS or not isinstance(value, list):
+        return False
+    global _DISABLED, _cache, _PAGE_INDEX
+    with _lock:
+        if _cache is None:
+            _cache = {}
+        _cache[key] = value
+        if key == "browser_pages":
+            _PAGE_INDEX = None
+        _DISABLED = False
+    return True
+
+
+def replace_browser_pages(pages: List[Dict[str, Any]]) -> bool:
+    """Replace the in-memory browser shard, bounding browser replay memory."""
+    if not isinstance(pages, list):
+        return False
+    return install_section("browser_pages", pages)
+
+
+def section_loaded(key: str) -> bool:
+    p = _cache
+    return not _DISABLED and isinstance(p, dict) and key in p
+
+
 def has_loaded_pack() -> bool:
-    """Return whether an archive is already resident in the runtime cache."""
+    """Return whether at least the archive core is resident."""
     return not _DISABLED and _cache is not None
 
 
 def bind_runtime_loader(loader: RuntimePackLoader):
-    """Bind an async runtime loader for the current execution context."""
+    """Bind the async Cloudflare core loader for the current ASGI task."""
     return _RUNTIME_PACK_LOADER.set(loader)
 
 
 def reset_runtime_loader(token) -> None:
-    """Restore the previous runtime-pack loader binding."""
     _RUNTIME_PACK_LOADER.reset(token)
 
 
 async def ensure_runtime_pack() -> bool:
-    """Ensure the live archive is ready before a world is constructed.
-
-    Local execution falls back to the on-disk JSON. Cloudflare binds an async
-    R2 loader around the ASGI task so WebSocket handlers can accept the socket
-    first, then await the large archive without delaying the HTTP 101 upgrade.
-    """
+    """Ensure the core archive is present before constructing WorldSession."""
     if _DISABLED:
         return False
     if has_loaded_pack():
@@ -119,7 +152,7 @@ def _pack() -> Optional[Dict[str, Any]]:
             return None
         try:
             data = json.loads(PACK_PATH.read_text(encoding="utf-8"))
-        except Exception as exc:  # corrupted pack must not break the server
+        except Exception as exc:
             print(f"[live_pack] failed to load {PACK_PATH}: {exc}")
             return None
         if not isinstance(data, dict):
@@ -136,13 +169,20 @@ def summary() -> str:
     p = _pack()
     if not p:
         return "live pack: not installed"
+
+    def count(key: str) -> str:
+        value = p.get(key)
+        return str(len(value)) if isinstance(value, list) else "lazy"
+
+    facts_value = p.get("facts")
+    fact_count = len(facts_value) if isinstance(facts_value, dict) else 0
     return (
-        f"live pack: mails={len(p.get('mail_artifacts', []))} "
-        f"files={len(p.get('file_artifacts', []))} "
-        f"threads={len(p.get('signal_thread_artifacts', []))} "
-        f"messages={len(p.get('signal_message_artifacts', []))} "
-        f"pages={len(p.get('browser_pages', []))} "
-        f"facts={len(p.get('facts', {}))} world={p.get('world_id', '')}"
+        f"live pack: mails={count('mail_artifacts')} "
+        f"files={count('file_artifacts')} "
+        f"threads={count('signal_thread_artifacts')} "
+        f"messages={count('signal_message_artifacts')} "
+        f"pages={count('browser_pages')} "
+        f"facts={fact_count} world={p.get('world_id', '')}"
     )
 
 
@@ -170,13 +210,8 @@ def signal_message_artifacts() -> List[Dict[str, Any]]:
     return _list("signal_message_artifacts")
 
 
-def _canonical(url: str) -> str:
-    """Scheme/query-preserving canonicalization.
-
-    Live lookups distinguish http vs https AND rely on query strings
-    (e.g. ``/t/1822?b=recent`` and the IPv6 cloud drive), so only host case,
-    fragment, and duplicate slashes are normalized.
-    """
+def canonical_lookup(url: str) -> str:
+    """Scheme/query-preserving canonicalization used by local and R2 indexes."""
     raw = (url or "").strip()
     try:
         parts = urlsplit(raw)
@@ -189,61 +224,55 @@ def _canonical(url: str) -> str:
     return f"{parts.scheme.lower()}://{parts.netloc.lower()}{path}{query}"
 
 
-def page(lookup_key: str) -> Optional[Dict[str, Any]]:
-    """Find an archived browser page by any recorded lookup alias.
+def lookup_variants(url: str) -> set[str]:
+    """Return the forgiving URL variants used by the archived browser."""
+    c = canonical_lookup(url)
+    variants = {c, c.rstrip("/"), c.rstrip("/") + "/"}
+    if "://" in c:
+        swapped = (
+            "https://" + c.split("://", 1)[1]
+            if c.startswith("http://")
+            else "http://" + c.split("://", 1)[1]
+        )
+        variants.update({swapped, swapped.rstrip("/"), swapped.rstrip("/") + "/"})
+    return {item for item in variants if item}
 
-    The production server keys pages on exact scheme+query (e.g.
-    ``/t/1843?b=intel`` differs from ``/t/1843?b=recent`` only by which board
-    highlighted it), so we index every alias the archive captured plus a few
-    auto-relaxed variants to stay forgiving with client-constructed URLs.
-    """
+
+def page(lookup_key: str) -> Optional[Dict[str, Any]]:
+    """Find an archived browser page in the currently installed local/R2 shard."""
     global _PAGE_INDEX
     if not lookup_key:
         return None
     if _PAGE_INDEX is None:
         idx: Dict[str, Dict[str, Any]] = {}
         for entry in _list("browser_pages"):
-            entries_for_page: List[Dict[str, Any]] = [entry]
-            variants: set[str] = set()
-            for alias in ({entry.get("key"), (entry.get("data") or {}).get("url")}
-                          | set(entry.get("aliases") or [])):
+            aliases = {
+                entry.get("key"),
+                (entry.get("data") or {}).get("url"),
+                *(entry.get("aliases") or []),
+            }
+            for alias in aliases:
                 if not alias:
                     continue
-                c = _canonical(alias)
-                variants.add(c)
-                variants.add(c.rstrip("/"))
-                variants.add(c + "/")
-                if "://" in c:
-                    swapped = ("https://" + c.split("://", 1)[1]
-                               if c.startswith("http://")
-                               else "http://" + c.split("://", 1)[1])
-                    variants.add(swapped)
-                    variants.add(swapped.rstrip("/"))
-            for v in variants:
-                if v and v not in idx:
-                    prev = next((e for e in entries_for_page), entry)
-                    idx[v] = prev
-            for v in variants:
-                idx.setdefault(v, entry)
+                for variant in lookup_variants(str(alias)):
+                    idx.setdefault(variant, entry)
         _PAGE_INDEX = idx
-    canon = _canonical(lookup_key)
+
+    canon = canonical_lookup(lookup_key)
     entry = _PAGE_INDEX.get(canon)
     if not entry:
-        # Query-insensitive fallback: single-page apps such as the Doodle
-        # search shim serve EVERY ``?q=…`` lookup from one archived page.
         base_no_q = canon.split("?", 1)[0]
-        candidates = {k: e for k, e in _PAGE_INDEX.items()
-                      if k.split("?", 1)[0] == base_no_q and "?" not in k}
-        if len({id(e) for e in candidates.values()}) == 1:
+        candidates = {
+            key: value
+            for key, value in _PAGE_INDEX.items()
+            if key.split("?", 1)[0] == base_no_q and "?" not in key
+        }
+        if len({id(value) for value in candidates.values()}) == 1:
             entry = next(iter(candidates.values()))
-    if not entry:
-        return None
-    out = copy.deepcopy(entry)
-    return out
+    return copy.deepcopy(entry) if entry else None
 
 
 def all_pages_raw() -> List[Dict[str, Any]]:
-    """Pages in archived form: {'key': ..., 'id': ..., 'data': {...}}."""
     return _list("browser_pages")
 
 

--- a/docs/CLOUDFLARE_LIVE_PACK.md
+++ b/docs/CLOUDFLARE_LIVE_PACK.md
@@ -1,38 +1,60 @@
 # Cloudflare live-world archive
 
-Cloudflare Workers must not bundle `backend/data/live_world_pack.json` into the Worker script because the archive is large and would exceed the Free-plan script-size limit.
+Cloudflare should not bundle or decode the complete `backend/data/live_world_pack.json` inside the Durable Object. The source archive is about 11.7 MiB on disk and expands substantially when decoded into Python objects.
 
-The Worker reads the archive privately from the existing `NORI_ASSETS_R2` binding instead.
+The Cloudflare deployment therefore keeps the source file in the repository but uploads a partitioned layout to the existing private `NORI_ASSETS_R2` bucket (`nori-web-assets`). The Durable Object loads only the lightweight core at startup. Mail, Files, Signal data, and browser-page shards are fetched from R2 only when the client requests them.
 
-## Upload the archive
+## Prepare and upload the R2 layout
 
-The configured bucket is `nori-web-assets` and the required object key is:
-
-```text
-runtime/live_world_pack.json
-```
-
-Upload the repository copy with Wrangler:
-
-```bash
-uv run pywrangler r2 object put nori-web-assets/runtime/live_world_pack.json \
-  --file=backend/data/live_world_pack.json \
-  --content-type=application/json \
-  --remote
-```
-
-On PowerShell, the same command can be entered on one line:
+Run a dry preparation first to see the object count and largest shard:
 
 ```powershell
-uv run pywrangler r2 object put nori-web-assets/runtime/live_world_pack.json --file=backend/data/live_world_pack.json --content-type=application/json --remote
+uv run python scripts/upload_cloudflare_live_pack.py
 ```
 
-Then deploy normally:
+Then upload the generated layout directly to the existing private R2 bucket:
 
-```bash
+```powershell
+uv run python scripts/upload_cloudflare_live_pack.py --upload
+```
+
+The script reads `backend/data/live_world_pack.json` and creates temporary objects under:
+
+```text
+runtime/live/core.json
+runtime/live/mail_artifacts.json
+runtime/live/file_artifacts.json
+runtime/live/signal_thread_artifacts.json
+runtime/live/signal_message_artifacts.json
+runtime/live/browser-index.json
+runtime/live/browser/<shard>.json
+```
+
+Browser pages are split into 32 deterministic shards by default. The generated files live only in a temporary directory while uploading; they are not committed to Git.
+
+The old object `runtime/live_world_pack.json` is no longer read by the sharded Worker and may be left in R2 or deleted later.
+
+## Deploy
+
+After uploading the layout, deploy normally:
+
+```powershell
 uv run pywrangler deploy
 ```
 
-`NORI_DISABLE_LIVE_PACK` defaults to `0` for the Cloudflare deployment. Set it to `1` only when you explicitly want mock/demo data.
+`NORI_DISABLE_LIVE_PACK` defaults to `0` for Cloudflare. Set it to `1` only when mock/demo data is explicitly desired.
 
-At runtime, each Worker isolate loads the archive from R2 on first use and keeps the decoded data in memory for subsequent requests. If the R2 object is missing or invalid, the service stays available and falls back to mock data while logging the reason.
+Expected cold-start logs now look like:
+
+```text
+[live_pack] core loaded from R2: live pack: mails=lazy files=lazy threads=lazy messages=lazy pages=lazy facts=120 world=...
+```
+
+Opening individual apps causes only the required sections to appear, for example:
+
+```text
+[live_pack] section loaded: mail_artifacts=15
+[live_pack] browser shard loaded: 0a pages=...
+```
+
+The R2 bucket should remain private; the Worker accesses it through the `NORI_ASSETS_R2` binding and does not require a public R2 URL or R2 access-key secret.

--- a/scripts/upload_cloudflare_live_pack.py
+++ b/scripts/upload_cloudflare_live_pack.py
@@ -1,0 +1,203 @@
+"""Prepare and optionally upload a memory-safe Cloudflare live-world layout.
+
+The source archive remains `backend/data/live_world_pack.json`. Cloudflare
+receives a lightweight core, four artifact sections, a small browser index,
+and hashed browser shards in the existing private R2 bucket.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_PACK = ROOT / "backend" / "data" / "live_world_pack.json"
+R2_PREFIX = "runtime/live"
+HEAVY_KEYS = {
+    "mail_artifacts",
+    "file_artifacts",
+    "signal_thread_artifacts",
+    "signal_message_artifacts",
+    "browser_pages",
+}
+
+
+def canonical_lookup(url: str) -> str:
+    raw = (url or "").strip()
+    try:
+        parts = urlsplit(raw)
+    except Exception:
+        return raw.lower()
+    if not parts.netloc:
+        return re.sub(r"/{2,}", "/", raw).lower()
+    path = re.sub(r"/{2,}", "/", parts.path or "")
+    query = f"?{parts.query}" if parts.query else ""
+    return f"{parts.scheme.lower()}://{parts.netloc.lower()}{path}{query}"
+
+
+def lookup_variants(url: str) -> set[str]:
+    c = canonical_lookup(url)
+    variants = {c, c.rstrip("/"), c.rstrip("/") + "/"}
+    if "://" in c:
+        swapped = (
+            "https://" + c.split("://", 1)[1]
+            if c.startswith("http://")
+            else "http://" + c.split("://", 1)[1]
+        )
+        variants.update({swapped, swapped.rstrip("/"), swapped.rstrip("/") + "/"})
+    return {item for item in variants if item}
+
+
+def _page_seed(entry: dict[str, Any], index: int) -> str:
+    data = entry.get("data") if isinstance(entry.get("data"), dict) else {}
+    for value in (entry.get("key"), data.get("url"), entry.get("id")):
+        if isinstance(value, str) and value:
+            return canonical_lookup(value)
+    return f"page-{index}"
+
+
+def partition_pack(pack: dict[str, Any], shard_count: int = 32) -> dict[str, Any]:
+    if shard_count < 1 or shard_count > 256:
+        raise ValueError("shard_count must be between 1 and 256")
+
+    objects: dict[str, Any] = {
+        f"{R2_PREFIX}/core.json": {
+            key: value for key, value in pack.items() if key not in HEAVY_KEYS
+        },
+        f"{R2_PREFIX}/mail_artifacts.json": pack.get("mail_artifacts", []),
+        f"{R2_PREFIX}/file_artifacts.json": pack.get("file_artifacts", []),
+        f"{R2_PREFIX}/signal_thread_artifacts.json": pack.get(
+            "signal_thread_artifacts", []
+        ),
+        f"{R2_PREFIX}/signal_message_artifacts.json": pack.get(
+            "signal_message_artifacts", []
+        ),
+    }
+
+    pages = pack.get("browser_pages")
+    pages = pages if isinstance(pages, list) else []
+    width = max(2, len(f"{shard_count - 1:x}"))
+    shards: dict[str, list[dict[str, Any]]] = {}
+    entries: dict[str, str] = {}
+
+    for index, raw_entry in enumerate(pages):
+        if not isinstance(raw_entry, dict):
+            continue
+        seed = _page_seed(raw_entry, index)
+        number = int.from_bytes(
+            hashlib.sha256(seed.encode("utf-8")).digest()[:4], "big"
+        )
+        shard = f"{number % shard_count:0{width}x}"
+        shards.setdefault(shard, []).append(raw_entry)
+
+        data = raw_entry.get("data") if isinstance(raw_entry.get("data"), dict) else {}
+        aliases = {
+            raw_entry.get("key"),
+            data.get("url"),
+            *(raw_entry.get("aliases") or []),
+        }
+        for alias in aliases:
+            if not isinstance(alias, str) or not alias:
+                continue
+            for variant in lookup_variants(alias):
+                entries.setdefault(variant, shard)
+
+    objects[f"{R2_PREFIX}/browser-index.json"] = {
+        "version": 1,
+        "shards": shard_count,
+        "entries": entries,
+    }
+    for shard, shard_pages in sorted(shards.items()):
+        objects[f"{R2_PREFIX}/browser/{shard}.json"] = shard_pages
+    return objects
+
+
+def _write_object(root: Path, key: str, data: Any) -> Path:
+    target = root / Path(*key.split("/"))
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(
+        json.dumps(data, ensure_ascii=False, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    return target
+
+
+def _pywrangler_command() -> list[str]:
+    executable = shutil.which("pywrangler")
+    if executable:
+        return [executable]
+    return ["uv", "run", "pywrangler"]
+
+
+def upload_objects(bucket: str, files: list[tuple[str, Path]]) -> None:
+    base = _pywrangler_command()
+    total = len(files)
+    for position, (key, path) in enumerate(files, 1):
+        print(
+            f"[{position:02d}/{total:02d}] {key} "
+            f"({path.stat().st_size / 1024:.1f} KiB)"
+        )
+        subprocess.run(
+            [
+                *base,
+                "r2",
+                "object",
+                "put",
+                f"{bucket}/{key}",
+                f"--file={path}",
+                "--content-type=application/json",
+                "--remote",
+            ],
+            cwd=ROOT,
+            check=True,
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bucket", default="nori-web-assets")
+    parser.add_argument("--shards", type=int, default=32)
+    parser.add_argument(
+        "--upload",
+        action="store_true",
+        help="Upload the prepared objects to R2. Without this flag only report sizes.",
+    )
+    args = parser.parse_args()
+
+    pack = json.loads(SOURCE_PACK.read_text(encoding="utf-8"))
+    if not isinstance(pack, dict):
+        raise SystemExit("live_world_pack.json root must be a JSON object")
+
+    objects = partition_pack(pack, args.shards)
+    with tempfile.TemporaryDirectory(prefix="nori-live-pack-") as temp:
+        root = Path(temp)
+        files = [(key, _write_object(root, key, data)) for key, data in objects.items()]
+        total_bytes = sum(path.stat().st_size for _, path in files)
+        largest = max(files, key=lambda item: item[1].stat().st_size)
+
+        print(
+            f"Prepared {len(files)} R2 objects from {SOURCE_PACK.name}: "
+            f"{total_bytes / 1024 / 1024:.2f} MiB total"
+        )
+        print(
+            f"Largest object: {largest[0]} "
+            f"({largest[1].stat().st_size / 1024:.1f} KiB)"
+        )
+        if not args.upload:
+            print("Dry run only. Re-run with --upload to write these objects to R2.")
+            return
+        upload_objects(args.bucket, files)
+
+    print("Live-world R2 layout uploaded successfully.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_live_pack_runtime.py
+++ b/tests/test_live_pack_runtime.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import asyncio
+import importlib.util
 import sys
 from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
 
 from backend.virtual_apps import live_pack
 
@@ -29,7 +31,7 @@ def _sample() -> dict:
     }
 
 
-def _assert_accessors() -> None:
+def _assert_full_accessors() -> None:
     assert live_pack.has_loaded_pack()
     assert live_pack.is_available()
     assert live_pack.mail_artifacts()[0]["id"] == "mail-1"
@@ -47,22 +49,44 @@ def _assert_accessors() -> None:
     assert live_pack.mail_artifacts()[0]["subject"] == "hello"
 
 
-async def main() -> None:
-    # Existing direct injection path remains valid.
-    live_pack.set_disabled(False)
-    assert live_pack.install_pack(_sample())
-    _assert_accessors()
+def _load_partition_module():
+    path = ROOT / "scripts" / "upload_cloudflare_live_pack.py"
+    spec = importlib.util.spec_from_file_location("nori_live_partition", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
-    # Cloudflare binds a loader before dispatching the ASGI WebSocket task,
-    # but simply binding it must not trigger any I/O. The load happens only
-    # when the accepted Arcade handler explicitly calls ensure_runtime_pack().
+
+async def main() -> None:
+    sample = _sample()
+
+    # Local/direct complete injection remains valid.
+    live_pack.set_disabled(False)
+    assert live_pack.install_pack(sample)
+    _assert_full_accessors()
+
+    # Cloudflare binds a loader before dispatching the ASGI WebSocket task.
+    # The loader now installs only the small core needed for WorldSession.
     live_pack.set_disabled(True)
     live_pack.set_disabled(False)
     calls: list[str] = []
 
     async def deferred_loader() -> bool:
         calls.append("load")
-        return live_pack.install_pack(_sample())
+        core = {
+            key: value
+            for key, value in sample.items()
+            if key
+            not in {
+                "mail_artifacts",
+                "file_artifacts",
+                "signal_thread_artifacts",
+                "signal_message_artifacts",
+                "browser_pages",
+            }
+        }
+        return live_pack.install_core(core)
 
     token = live_pack.bind_runtime_loader(deferred_loader)
     try:
@@ -70,17 +94,58 @@ async def main() -> None:
         assert not live_pack.has_loaded_pack()
         assert await live_pack.ensure_runtime_pack()
         assert calls == ["load"]
-        _assert_accessors()
-        # Once resident, subsequent world opens do not re-fetch R2.
+        assert live_pack.facts()["chapter"] == 7
+        assert live_pack.variables()["flag"] is True
+        assert live_pack.chip_status()["online"] is True
+        assert not live_pack.section_loaded("mail_artifacts")
+        assert live_pack.mail_artifacts() == []
+        assert "mails=lazy" in live_pack.summary()
+
+        # Artifact sections can be attached independently without replacing core.
+        assert live_pack.install_section("mail_artifacts", sample["mail_artifacts"])
+        assert live_pack.install_section("file_artifacts", sample["file_artifacts"])
+        assert live_pack.install_section(
+            "signal_thread_artifacts", sample["signal_thread_artifacts"]
+        )
+        assert live_pack.install_section(
+            "signal_message_artifacts", sample["signal_message_artifacts"]
+        )
+        assert live_pack.mail_artifacts()[0]["subject"] == "hello"
+        assert live_pack.file_artifacts()[0]["id"] == "file-1"
+
+        # Browser replay is explicitly replaceable so only one R2 shard must
+        # remain resident at a time.
+        assert live_pack.replace_browser_pages(sample["browser_pages"])
+        assert live_pack.page("https://example.test/page?q=1")["data"]["title"] == "Example"
+        assert live_pack.page("http://example.test/page?q=1")["data"]["title"] == "Example"
+        assert live_pack.replace_browser_pages([])
+        assert live_pack.page("https://example.test/page?q=1") is None
+
+        # Once the core is resident, a second world open does not re-fetch it.
         assert await live_pack.ensure_runtime_pack()
         assert calls == ["load"]
     finally:
         live_pack.reset_runtime_loader(token)
 
+    # The uploader must produce a core with no heavy arrays plus an alias index
+    # that points both http/https forms to the same browser shard.
+    partition = _load_partition_module()
+    objects = partition.partition_pack(sample, shard_count=4)
+    core = objects["runtime/live/core.json"]
+    assert "browser_pages" not in core
+    assert "mail_artifacts" not in core
+    index = objects["runtime/live/browser-index.json"]["entries"]
+    assert index["https://example.test/page?q=1"] == index[
+        "http://example.test/page?q=1"
+    ]
+    shard = index["https://example.test/page?q=1"]
+    pages = objects[f"runtime/live/browser/{shard}.json"]
+    assert pages[0]["data"]["title"] == "Example"
+
     live_pack.set_disabled(True)
     assert not live_pack.has_loaded_pack()
     assert live_pack.mail_artifacts() == []
-    print("[ok] runtime live-world pack loading is deferred until explicitly ensured")
+    print("[ok] live-world core, lazy sections, and browser sharding behave correctly")
 
 
 if __name__ == "__main__":

--- a/worker.py
+++ b/worker.py
@@ -1,11 +1,14 @@
 """Cloudflare Workers entrypoint for Nori.Web.
 
-HTTP API requests are served through Cloudflare's Python ASGI adapter. Static
-frontend files are served by Workers Static Assets. Arcade WebSocket pairs are
-routed by their signed ticket into a Durable Object so the main and media
-channels share one in-memory WorldManager. Oversized static assets and the
-private live-world archive are read from R2 so they do not consume Worker
-script-size quota.
+HTTP APIs are served through Cloudflare's Python ASGI adapter, static frontend
+files through Workers Static Assets, and Arcade WebSockets through a Durable
+Object. Large immutable assets and the live-world archive live in private R2.
+
+The live archive is deliberately partitioned: only a small core is resident
+when a world starts, artifact sections are fetched before the corresponding
+WebSocket RPC is dispatched, and browser pages are loaded one shard at a time.
+This avoids holding the original 11.7 MiB JSON as a large Python object inside
+the 128 MiB Durable Object isolate.
 """
 
 from __future__ import annotations
@@ -29,31 +32,45 @@ from server import create_app
 
 _FASTAPI_APP = create_app(include_static=False)
 _TRUE_VALUES = {"1", "true", "yes", "on"}
+
 _R2_MODEL_PATH = "/datasea/cosmicweb.min.glb"
 _R2_MODEL_KEY = "datasea/cosmicweb.min.glb"
 _R2_MODEL_CONTENT_TYPE = "model/gltf-binary"
 _R2_MODEL_CACHE_CONTROL = "public, max-age=604800, immutable"
-_R2_LIVE_PACK_KEY = "runtime/live_world_pack.json"
+
+_R2_LIVE_PREFIX = "runtime/live"
+_R2_LIVE_CORE_KEY = f"{_R2_LIVE_PREFIX}/core.json"
+_R2_LIVE_SECTION_KEYS = {
+    "mail_artifacts": f"{_R2_LIVE_PREFIX}/mail_artifacts.json",
+    "file_artifacts": f"{_R2_LIVE_PREFIX}/file_artifacts.json",
+    "signal_thread_artifacts": f"{_R2_LIVE_PREFIX}/signal_thread_artifacts.json",
+    "signal_message_artifacts": f"{_R2_LIVE_PREFIX}/signal_message_artifacts.json",
+}
+_R2_BROWSER_INDEX_KEY = f"{_R2_LIVE_PREFIX}/browser-index.json"
+_R2_BROWSER_SHARD_PREFIX = f"{_R2_LIVE_PREFIX}/browser"
+
 _LIVE_PACK_LOAD_LOCK = asyncio.Lock()
 _LIVE_PACK_RETRY_SECONDS = 60.0
 _live_pack_retry_at = 0.0
+_browser_index: dict[str, str] | None = None
+_browser_loaded_shard: str | None = None
 
 
 def _apply_runtime_bindings(env) -> None:
-    """Apply Workers vars/secrets without doing any blocking R2 I/O."""
     config.apply_runtime_bindings(env)
     disabled = config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES
     live_pack.set_disabled(disabled)
 
 
-async def _load_live_pack_from_r2(env) -> bool:
-    """Load the private live archive into the current Worker/DO isolate.
+async def _r2_json(env, key: str):
+    obj = await env.NORI_ASSETS_R2.get(key)
+    if obj is None:
+        return None
+    return await obj.json()
 
-    This function is intentionally invoked from the Arcade ASGI handler only
-    after ``websocket.accept()``. Keeping the 11.7 MB R2 download and JSON
-    decode off the HTTP upgrade path prevents browsers from timing out while a
-    cold Durable Object initializes.
-    """
+
+async def _load_live_core_from_r2(env) -> bool:
+    """Load only facts/variables/chip state needed to construct a world."""
     global _live_pack_retry_at
 
     if config.NORI_DISABLE_LIVE_PACK.strip().lower() in _TRUE_VALUES:
@@ -68,36 +85,184 @@ async def _load_live_pack_from_r2(env) -> bool:
     async with _LIVE_PACK_LOAD_LOCK:
         if live_pack.has_loaded_pack():
             return True
-
         now = time.monotonic()
         if now < _live_pack_retry_at:
             return False
-
         try:
-            obj = await env.NORI_ASSETS_R2.get(_R2_LIVE_PACK_KEY)
-            if obj is None:
+            data = await _r2_json(env, _R2_LIVE_CORE_KEY)
+            if not isinstance(data, dict):
                 print(
-                    f"[live_pack] R2 object missing: {_R2_LIVE_PACK_KEY}; "
-                    "falling back to mock data"
+                    f"[live_pack] R2 core missing/invalid: {_R2_LIVE_CORE_KEY}; "
+                    "run scripts/upload_cloudflare_live_pack.py"
                 )
                 _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
                 return False
-
-            raw = await obj.text()
-            data = json.loads(raw)
-            del raw
-            if not live_pack.install_pack(data):
-                print("[live_pack] R2 archive root is not a JSON object; using mock data")
+            if not live_pack.install_core(data):
                 _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
                 return False
-
             _live_pack_retry_at = 0.0
-            print(f"[live_pack] loaded from R2: {live_pack.summary()}")
+            print(f"[live_pack] core loaded from R2: {live_pack.summary()}")
             return True
         except Exception as exc:
-            print(f"[live_pack] failed to load R2 archive: {exc}")
+            print(f"[live_pack] failed to load R2 core: {exc}")
             _live_pack_retry_at = now + _LIVE_PACK_RETRY_SECONDS
             return False
+
+
+async def _ensure_live_section(env, section: str) -> bool:
+    if live_pack.section_loaded(section):
+        return True
+    key = _R2_LIVE_SECTION_KEYS.get(section)
+    if key is None:
+        return False
+    async with _LIVE_PACK_LOAD_LOCK:
+        if live_pack.section_loaded(section):
+            return True
+        try:
+            data = await _r2_json(env, key)
+            if not isinstance(data, list):
+                print(f"[live_pack] R2 section missing/invalid: {key}")
+                return False
+            live_pack.install_section(section, data)
+            print(f"[live_pack] section loaded: {section}={len(data)}")
+            return True
+        except Exception as exc:
+            print(f"[live_pack] failed section {section}: {exc}")
+            return False
+
+
+async def _get_browser_index(env) -> dict[str, str]:
+    global _browser_index
+    if _browser_index is not None:
+        return _browser_index
+    async with _LIVE_PACK_LOAD_LOCK:
+        if _browser_index is not None:
+            return _browser_index
+        try:
+            data = await _r2_json(env, _R2_BROWSER_INDEX_KEY)
+            entries = data.get("entries") if isinstance(data, dict) else None
+            if not isinstance(entries, dict):
+                print(f"[live_pack] browser index missing/invalid: {_R2_BROWSER_INDEX_KEY}")
+                _browser_index = {}
+            else:
+                _browser_index = {
+                    str(key): str(value)
+                    for key, value in entries.items()
+                    if isinstance(key, str) and isinstance(value, (str, int))
+                }
+        except Exception as exc:
+            print(f"[live_pack] failed browser index: {exc}")
+            _browser_index = {}
+    return _browser_index
+
+
+def _lookup_browser_shard(
+    index: dict[str, str],
+    lookup_key: str,
+    *,
+    allow_contains: bool = False,
+) -> str | None:
+    for variant in live_pack.lookup_variants(lookup_key):
+        shard = index.get(variant)
+        if shard is not None:
+            return shard
+
+    canon = live_pack.canonical_lookup(lookup_key)
+    base_no_q = canon.split("?", 1)[0]
+    queryless = {
+        shard
+        for key, shard in index.items()
+        if "?" not in key and key.split("?", 1)[0] == base_no_q
+    }
+    if len(queryless) == 1:
+        return next(iter(queryless))
+
+    if allow_contains and canon:
+        matches = {shard for key, shard in index.items() if canon in key or key in canon}
+        if len(matches) == 1:
+            return next(iter(matches))
+    return None
+
+
+async def _ensure_browser_lookup(
+    env,
+    lookup_key: str,
+    *,
+    allow_contains: bool = False,
+) -> bool:
+    global _browser_loaded_shard
+    index = await _get_browser_index(env)
+    shard = _lookup_browser_shard(index, lookup_key, allow_contains=allow_contains)
+    if shard is None:
+        live_pack.replace_browser_pages([])
+        _browser_loaded_shard = None
+        return False
+
+    if _browser_loaded_shard == shard and live_pack.section_loaded("browser_pages"):
+        return True
+
+    key = f"{_R2_BROWSER_SHARD_PREFIX}/{shard}.json"
+    async with _LIVE_PACK_LOAD_LOCK:
+        if _browser_loaded_shard == shard and live_pack.section_loaded("browser_pages"):
+            return True
+        try:
+            data = await _r2_json(env, key)
+            if not isinstance(data, list):
+                print(f"[live_pack] browser shard missing/invalid: {key}")
+                return False
+            live_pack.replace_browser_pages(data)
+            _browser_loaded_shard = shard
+            print(f"[live_pack] browser shard loaded: {shard} pages={len(data)}")
+            return True
+        except Exception as exc:
+            print(f"[live_pack] failed browser shard {shard}: {exc}")
+            return False
+
+
+async def _prefetch_for_arcade_message(env, raw: str) -> None:
+    """Populate lazy archive sections before EventDispatcher handles an RPC."""
+    try:
+        message = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return
+    if not isinstance(message, dict) or message.get("type") != "event":
+        return
+
+    channel = message.get("channel")
+    payload = message.get("payload")
+    payload = payload if isinstance(payload, dict) else {}
+
+    if channel == "manifold.artifacts.request":
+        req_type = payload.get("artifactType")
+        mapping = {
+            "mail": ("mail_artifacts",),
+            "file": ("file_artifacts",),
+            "signal_thread": ("signal_thread_artifacts",),
+            "signal_message": ("signal_message_artifacts",),
+            None: (
+                "mail_artifacts",
+                "file_artifacts",
+                "signal_thread_artifacts",
+                "signal_message_artifacts",
+            ),
+        }
+        for section in mapping.get(req_type, ()):
+            await _ensure_live_section(env, section)
+        return
+
+    if channel == "manifold.artifacts.fetch":
+        if payload.get("artifactType") == "browser_page":
+            lookup_key = payload.get("lookup_key")
+            if isinstance(lookup_key, str) and lookup_key:
+                await _ensure_browser_lookup(env, lookup_key)
+        return
+
+    if channel == "manifold.bounty.submit":
+        if payload.get("fileId"):
+            await _ensure_live_section(env, "file_artifacts")
+        url = payload.get("url")
+        if isinstance(url, str) and url:
+            await _ensure_browser_lookup(env, url, allow_contains=True)
 
 
 def _is_websocket(request) -> bool:
@@ -136,7 +301,6 @@ def _r2_headers(obj) -> dict[str, str]:
 
 
 async def _serve_r2_model(env, request):
-    """Stream the oversized DataSea GLB from the private R2 bucket."""
     if request.method == "HEAD":
         obj = await env.NORI_ASSETS_R2.head(_R2_MODEL_KEY)
         if obj is None:
@@ -153,19 +317,11 @@ async def _serve_r2_model(env, request):
     obj = await env.NORI_ASSETS_R2.get(_R2_MODEL_KEY)
     if obj is None:
         return Response("Object Not Found", status=404)
-
     return Response(obj.body, status=200, headers=_r2_headers(obj))
 
 
 async def _cloudflare_asgi_app(scope, receive, send) -> None:
-    """Patch Cloudflare's WebSocket ASGI scope with requested subprotocols.
-
-    The current Workers ASGI adapter exposes the raw
-    ``Sec-WebSocket-Protocol`` header but does not populate ASGI's
-    ``scope['subprotocols']`` field. Starlette uses that field for WebSocket
-    protocol negotiation, so populate it here before FastAPI receives the
-    scope.
-    """
+    """Patch subprotocols and lazily prefetch R2 sections for WS messages."""
     if scope.get("type") == "websocket" and not scope.get("subprotocols"):
         protocols: list[str] = []
         for key, value in scope.get("headers", []):
@@ -177,7 +333,27 @@ async def _cloudflare_asgi_app(scope, receive, send) -> None:
                 )
         scope = dict(scope)
         scope["subprotocols"] = protocols
-    await _FASTAPI_APP(scope, receive, send)
+
+    if scope.get("type") != "websocket":
+        await _FASTAPI_APP(scope, receive, send)
+        return
+
+    env = scope.get("env")
+
+    async def receive_with_prefetch():
+        event = await receive()
+        if event.get("type") == "websocket.receive" and env is not None:
+            raw = event.get("text")
+            if raw is None and isinstance(event.get("bytes"), (bytes, bytearray)):
+                try:
+                    raw = bytes(event["bytes"]).decode("utf-8")
+                except UnicodeDecodeError:
+                    raw = None
+            if isinstance(raw, str):
+                await _prefetch_for_arcade_message(env, raw)
+        return event
+
+    await _FASTAPI_APP(scope, receive_with_prefetch, send)
 
 
 class NoriArcadeSession(DurableObject):
@@ -191,14 +367,11 @@ class NoriArcadeSession(DurableObject):
         _apply_runtime_bindings(self.env)
         manager_token = bind_world_manager(self.manager)
         loader_token = live_pack.bind_runtime_loader(
-            lambda: _load_live_pack_from_r2(self.env)
+            lambda: _load_live_core_from_r2(self.env)
         )
         try:
             if _is_websocket(request):
                 response = await asgi.websocket(_cloudflare_asgi_app, request, self.env)
-                # Workers' ASGI WebSocket adapter currently ignores the
-                # subprotocol selected by ``websocket.accept``. Echo the
-                # protocol explicitly so browsers accept the upgrade.
                 if "arcade.v1" in _requested_protocols(request):
                     response.headers.set("Sec-WebSocket-Protocol", "arcade.v1")
                 return response
@@ -212,9 +385,6 @@ class Default(WorkerEntrypoint):
     """Route API, R2 assets, and frontend traffic to the correct service."""
 
     async def fetch(self, request):
-        # Authentication, entry-status and ticket issuance must stay fast.
-        # Do not fetch/decode the live archive in the ordinary Worker isolate;
-        # the Durable Object loads it after the WebSocket has been accepted.
         _apply_runtime_bindings(self.env)
         path = urlsplit(request.url).path
 


### PR DESCRIPTION
## Summary

Fixes the production Cloudflare failure where the full live-world archive loads successfully from R2 and the Arcade Durable Object is then immediately reset.

Observed production tail:

```text
[live_pack] loaded from R2: live pack: mails=15 files=46 threads=6 messages=36 pages=359 facts=120 world=...
Error: Durable Object connection closed because the object was reset.
```

The 11.7 MiB source JSON expands substantially as Python dict/list/string objects. Keeping the entire decoded archive inside the Python Durable Object creates an avoidable memory spike and retains all 359 browser pages even when the client has not opened the Browser app.

### Fix

- keeps `backend/data/live_world_pack.json` as the canonical source archive
- adds `scripts/upload_cloudflare_live_pack.py` to partition and upload it to the existing private `nori-web-assets` R2 bucket
- stores a small `runtime/live/core.json` containing world id, facts, variables, chip state, and other non-artifact state
- stores Mail, Files, Signal threads, and Signal messages as independent R2 objects
- hashes the 359 archived browser pages across 32 deterministic R2 shards and generates a small alias-to-shard index
- loads only the core before constructing `WorldSession`
- intercepts incoming Arcade RPC messages before `EventDispatcher` and loads only the section required for that request
- retains at most one browser-page shard in the live-pack browser cache at a time
- preserves the complete local/on-disk archive behavior
- adds tests for partial core injection, lazy sections, replaceable browser shards, and uploader alias/shard correctness

### Required one-time R2 migration

After merging, prepare/check the layout:

```powershell
uv run python scripts/upload_cloudflare_live_pack.py
```

Then upload it:

```powershell
uv run python scripts/upload_cloudflare_live_pack.py --upload
```

Finally deploy normally:

```powershell
uv run pywrangler deploy
```

The old `runtime/live_world_pack.json` object is no longer used by this Worker and can remain in R2.