### PR TITLE
chore: enable Cloudflare Workers observability and tracing

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,6 +30,10 @@
     "command": "uv run python scripts/prepare_cloudflare_runtime.py",
     "cwd": "."
   },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1
+  },
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,7 +32,11 @@
   },
   "observability": {
     "enabled": true,
-    "head_sampling_rate": 1
+    "head_sampling_rate": 1,
+    "traces": {
+      "enabled": true,
+      "head_sampling_rate": 1
+    }
   },
   "assets": {
     "directory": "./public",


### PR DESCRIPTION
## Summary

Enables persisted Cloudflare Workers Logs and automatic tracing for the production `nori-web` Worker through Wrangler configuration.

### Configuration

```json
"observability": {
  "enabled": true,
  "head_sampling_rate": 1,
  "traces": {
    "enabled": true,
    "head_sampling_rate": 1
  }
}
```

This captures 100% of Worker invocations and traces while the Cloudflare deployment is being stabilized.

Workers Logs will persist invocation logs, application logs, errors, and uncaught exceptions. Automatic traces will expose handler spans and binding calls, including Durable Object and R2 interactions, which is especially useful for diagnosing the `Worker -> Durable Object -> R2` path in Nori.Web.

The sampling rates can be reduced later if traffic or observability volume grows.