### PR TITLE
feat: add persistent browser AI settings

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Verify runtime live pack injection
         run: uv run python tests/test_live_pack_runtime.py
 
+      - name: Verify browser AI settings
+        run: uv run python tests/test_ai_runtime_settings.py
+
+      - name: Verify browser AI settings JavaScript
+        run: node --check public/nori-ai-settings.js
+
       - name: Compile Python sources
         run: uv run python -m compileall -q backend server.py worker.py
 

--- a/backend/services/ai_event_bridge.py
+++ b/backend/services/ai_event_bridge.py
@@ -1,0 +1,40 @@
+"""Install the browser AI-settings bridge onto the verified event dispatcher.
+
+The shipped frontend bundle is treated as a compatibility target.  Keeping the
+new configuration on an Arcade event channel means secrets never become part
+of a cartridge command/transition while the existing protocol remains intact.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .ai_runtime_config import install_runtime_ai_config, public_runtime_ai_summary
+from .event_dispatcher import EventDispatcher
+
+_INSTALLED = False
+_ORIGINAL_HANDLE_EVENT = EventDispatcher.handle_event
+
+
+async def _handle_event_with_ai_settings(
+    self: EventDispatcher, message: Dict[str, Any]
+) -> Dict[str, Any]:
+    if message.get("channel") == "nori.ai.config":
+        payload = message.get("payload") if isinstance(message.get("payload"), dict) else {}
+        config = install_runtime_ai_config(payload)
+        return self.build_response(
+            "nori.ai.config.result",
+            public_runtime_ai_summary(config),
+            cartridge_id=message.get("cartridgeId"),
+            request_id=message.get("requestId"),
+        )
+    return await _ORIGINAL_HANDLE_EVENT(self, message)
+
+
+def install_ai_event_bridge() -> None:
+    """Patch EventDispatcher exactly once during application bootstrap."""
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    EventDispatcher.handle_event = _handle_event_with_ai_settings
+    _INSTALLED = True

--- a/backend/services/ai_runtime_config.py
+++ b/backend/services/ai_runtime_config.py
@@ -1,0 +1,119 @@
+"""Ephemeral AI configuration supplied by the browser Settings app.
+
+The browser persists its preferences locally, then sends the active settings
+through the existing Arcade ``event`` channel.  The server keeps the decoded
+configuration in a ContextVar so it follows the WebSocket task (and chat reply
+tasks spawned from it) without ever entering cartridge state, transitions, or
+Durable Object storage.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any, Dict
+from urllib.parse import urlsplit
+
+_ALLOWED_PROVIDERS = {"openai-compatible", "anthropic"}
+_RUNTIME_AI_CONFIG: ContextVar[Dict[str, Any] | None] = ContextVar(
+    "nori_runtime_ai_config", default=None
+)
+
+
+def _text(value: Any, *, limit: int) -> str:
+    if not isinstance(value, str):
+        return ""
+    value = value.strip()
+    return value[:limit]
+
+
+def _base_url(value: Any) -> str:
+    raw = _text(value, limit=1000).rstrip("/")
+    if not raw:
+        return ""
+    try:
+        parsed = urlsplit(raw)
+    except Exception:
+        return ""
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        return ""
+    # Never allow credentials in a URL; API credentials belong in the
+    # dedicated key field and must not appear in logs, traces, or error URLs.
+    if parsed.username is not None or parsed.password is not None:
+        return ""
+    return raw
+
+
+def _number(value: Any, default: float, low: float, high: float) -> float:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return default
+    return max(low, min(high, parsed))
+
+
+def _integer(value: Any, default: int, low: int, high: int) -> int:
+    if isinstance(value, bool):
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(low, min(high, parsed))
+
+
+def sanitize_runtime_ai_config(raw: Any) -> Dict[str, Any]:
+    """Validate an untrusted browser configuration.
+
+    API keys are accepted for the current WebSocket execution context but are
+    intentionally absent from :func:`public_runtime_ai_summary` and from every
+    cartridge state/transition.
+    """
+    if not isinstance(raw, dict):
+        raw = {}
+
+    provider = _text(raw.get("provider"), limit=40).lower()
+    if provider not in _ALLOWED_PROVIDERS:
+        provider = "openai-compatible"
+
+    return {
+        "enabled": raw.get("enabled") is True,
+        "provider": provider,
+        "baseUrl": _base_url(raw.get("baseUrl")),
+        "model": _text(raw.get("model"), limit=200),
+        "apiKey": _text(raw.get("apiKey"), limit=2048),
+        "systemPrompt": _text(raw.get("systemPrompt"), limit=16000),
+        "characterPrompt": _text(raw.get("characterPrompt"), limit=16000),
+        "temperature": _number(raw.get("temperature"), 0.75, 0.0, 2.0),
+        "maxTokens": _integer(raw.get("maxTokens"), 350, 32, 4096),
+    }
+
+
+def install_runtime_ai_config(raw: Any) -> Dict[str, Any]:
+    """Install browser settings in the current WebSocket task context."""
+    config = sanitize_runtime_ai_config(raw)
+    _RUNTIME_AI_CONFIG.set(config)
+    return config
+
+
+def get_runtime_ai_config() -> Dict[str, Any]:
+    config = _RUNTIME_AI_CONFIG.get()
+    return dict(config) if isinstance(config, dict) else {}
+
+
+def public_runtime_ai_summary(config: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Return acknowledgement metadata that can safely go back to the client."""
+    cfg = config if isinstance(config, dict) else get_runtime_ai_config()
+    return {
+        "ok": True,
+        "enabled": bool(cfg.get("enabled")),
+        "provider": str(cfg.get("provider") or "openai-compatible"),
+        "baseUrl": str(cfg.get("baseUrl") or ""),
+        "model": str(cfg.get("model") or ""),
+        "hasApiKey": bool(cfg.get("apiKey")),
+        "systemPromptLength": len(str(cfg.get("systemPrompt") or "")),
+        "characterPromptLength": len(str(cfg.get("characterPrompt") or "")),
+        "temperature": cfg.get("temperature", 0.75),
+        "maxTokens": cfg.get("maxTokens", 350),
+    }

--- a/backend/services/ai_runtime_config.py
+++ b/backend/services/ai_runtime_config.py
@@ -97,6 +97,11 @@ def install_runtime_ai_config(raw: Any) -> Dict[str, Any]:
     return config
 
 
+def clear_runtime_ai_config() -> None:
+    """Drop the current task's browser override (mainly useful in tests)."""
+    _RUNTIME_AI_CONFIG.set(None)
+
+
 def get_runtime_ai_config() -> Dict[str, Any]:
     config = _RUNTIME_AI_CONFIG.get()
     return dict(config) if isinstance(config, dict) else {}

--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -1,4 +1,4 @@
-"""LLM Service providing OpenAI-compatible requests and rule-based local fallbacks."""
+"""LLM service with browser-selectable providers and local fallback replies."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import httpx
 
 from ..core import config
+from .ai_runtime_config import get_runtime_ai_config
 
 EMOTIONS = {
     "happy",
@@ -35,15 +36,19 @@ EMOTION_ALIASES = {
     "sleep": "neutral",
 }
 
-SYSTEM_PROMPT = """You are Nori, the AI companion inside NoriOS. Be warm, concise,
-curious, and helpful. Reply in the user's language when practical. Start the
-answer with a single emotion tag selected from: happy, excited, sad, angry,
-fearful, disgusted, surprised, doubtful, dizzy, serious, neutral. Example:
-[emotion:happy] 你好！ Avoid claiming actions you have not performed."""
+DEFAULT_PERSONA_PROMPT = """You are Nori, the AI companion inside NoriOS. Be warm, concise,
+curious, and helpful. Reply in the user's language when practical. Avoid
+claiming actions you have not performed."""
+
+EMOTION_PROTOCOL_PROMPT = """NoriOS rendering contract: start every answer with exactly one emotion tag
+selected from happy, excited, sad, angry, fearful, disgusted, surprised,
+doubtful, dizzy, serious, neutral. Example: [emotion:happy] 你好！"""
+
+SYSTEM_PROMPT = f"{DEFAULT_PERSONA_PROMPT}\n\n{EMOTION_PROTOCOL_PROMPT}"
 
 
 class LLMService:
-    """Handles conversational agent generation with multi-provider and fallback support."""
+    """Handles conversational generation with per-browser runtime overrides."""
 
     @staticmethod
     def extract_emotion(text: str) -> Tuple[str, str]:
@@ -53,6 +58,113 @@ class LLMService:
         raw = match.group(1).lower()
         emotion = raw if raw in EMOTIONS else EMOTION_ALIASES.get(raw, "neutral")
         return emotion, re.sub(r"\[emotion:[a-zA-Z_]+\]", "", text, count=1).strip()
+
+    @staticmethod
+    def _prompt(runtime: Dict[str, Any]) -> str:
+        custom_system = str(runtime.get("systemPrompt") or "").strip()
+        character = str(runtime.get("characterPrompt") or "").strip()
+        if custom_system:
+            parts = [custom_system]
+            if character:
+                parts.append(character)
+            # Keep the wire-level emotion contract even when the user replaces
+            # the persona prompt, otherwise the Live2D presentation loses its
+            # emotion signal.
+            parts.append(EMOTION_PROTOCOL_PROMPT)
+            return "\n\n".join(parts)
+        if character:
+            return f"{SYSTEM_PROMPT}\n\n{character}"
+        return SYSTEM_PROMPT
+
+    @staticmethod
+    def _history(history: Optional[List[Dict[str, str]]]) -> List[Dict[str, str]]:
+        clean: List[Dict[str, str]] = []
+        for item in history or []:
+            if not isinstance(item, dict):
+                continue
+            role = item.get("role")
+            content = item.get("content")
+            if role in {"user", "assistant"} and isinstance(content, str) and content:
+                clean.append({"role": role, "content": content})
+        return clean
+
+    @classmethod
+    async def _openai_compatible_reply(
+        cls,
+        *,
+        user_text: str,
+        history: Optional[List[Dict[str, str]]],
+        base_url: str,
+        model: str,
+        api_key: str,
+        system_prompt: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        messages: List[Dict[str, str]] = [{"role": "system", "content": system_prompt}]
+        messages.extend(cls._history(history))
+        messages.append({"role": "user", "content": user_text})
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            response = await client.post(
+                f"{base_url.rstrip('/')}/chat/completions",
+                headers=headers,
+                json={
+                    "model": model,
+                    "messages": messages,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            return str(data["choices"][0]["message"]["content"])
+
+    @classmethod
+    async def _anthropic_reply(
+        cls,
+        *,
+        user_text: str,
+        history: Optional[List[Dict[str, str]]],
+        base_url: str,
+        model: str,
+        api_key: str,
+        system_prompt: str,
+        temperature: float,
+        max_tokens: int,
+    ) -> str:
+        messages = cls._history(history)
+        messages.append({"role": "user", "content": user_text})
+        headers = {
+            "Content-Type": "application/json",
+            "anthropic-version": "2023-06-01",
+        }
+        if api_key:
+            headers["x-api-key"] = api_key
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            response = await client.post(
+                f"{base_url.rstrip('/')}/messages",
+                headers=headers,
+                json={
+                    "model": model,
+                    "system": system_prompt,
+                    "messages": messages,
+                    "temperature": temperature,
+                    "max_tokens": max_tokens,
+                },
+            )
+            response.raise_for_status()
+            data = response.json()
+            blocks = data.get("content") if isinstance(data, dict) else None
+            if not isinstance(blocks, list):
+                return ""
+            return "".join(
+                str(block.get("text") or "")
+                for block in blocks
+                if isinstance(block, dict) and block.get("type") == "text"
+            ).strip()
 
     # 语料锚点来自档案里 Nori 的官方信件与消息，保持口吻一致。
     REUNION_LINES = (
@@ -98,31 +210,66 @@ class LLMService:
         user_text: str,
         history: Optional[List[Dict[str, str]]] = None,
     ) -> Tuple[str, str]:
-        if config.OPENAI_API_KEY:
-            try:
-                messages = [{"role": "system", "content": SYSTEM_PROMPT}]
-                if history:
-                    messages.extend(history)
-                messages.append({"role": "user", "content": user_text})
+        runtime = get_runtime_ai_config()
+        browser_override = runtime.get("enabled") is True
 
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    response = await client.post(
-                        f"{config.OPENAI_BASE_URL.rstrip('/')}/chat/completions",
-                        headers={"Authorization": f"Bearer {config.OPENAI_API_KEY}"},
-                        json={
-                            "model": config.OPENAI_MODEL,
-                            "messages": messages,
-                            "temperature": 0.75,
-                            "max_tokens": 350,
-                        },
-                    )
-                    response.raise_for_status()
-                    content = response.json()["choices"][0]["message"]["content"]
-                    emotion, cleaned = cls.extract_emotion(content)
-                    if cleaned:
-                        return emotion, cleaned
-            except Exception as exc:
-                print(f"[LLMService] Model request failed: {exc}")
+        if browser_override:
+            provider = str(runtime.get("provider") or "openai-compatible")
+            temperature = float(runtime.get("temperature", 0.75))
+            max_tokens = int(runtime.get("maxTokens", 350))
+            system_prompt = cls._prompt(runtime)
+            api_key = str(runtime.get("apiKey") or "")
+            if provider == "anthropic":
+                base_url = str(runtime.get("baseUrl") or "https://api.anthropic.com/v1")
+                model = str(runtime.get("model") or config.ANTHROPIC_MODEL)
+            else:
+                base_url = str(runtime.get("baseUrl") or "https://api.openai.com/v1")
+                model = str(runtime.get("model") or config.OPENAI_MODEL)
+        else:
+            provider = "openai-compatible"
+            temperature = 0.75
+            max_tokens = 350
+            system_prompt = SYSTEM_PROMPT
+            api_key = config.OPENAI_API_KEY
+            base_url = config.OPENAI_BASE_URL
+            model = config.OPENAI_MODEL
+
+        # The historical server-default path keeps its old behavior: no server
+        # key means immediate local fallback. Browser overrides are allowed to
+        # call no-auth OpenAI-compatible endpoints (for example a local proxy).
+        if not browser_override and not api_key:
+            return cls.local_fallback_reply(user_text)
+
+        try:
+            if provider == "anthropic":
+                content = await cls._anthropic_reply(
+                    user_text=user_text,
+                    history=history,
+                    base_url=base_url,
+                    model=model,
+                    api_key=api_key,
+                    system_prompt=system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            else:
+                content = await cls._openai_compatible_reply(
+                    user_text=user_text,
+                    history=history,
+                    base_url=base_url,
+                    model=model,
+                    api_key=api_key,
+                    system_prompt=system_prompt,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                )
+            emotion, cleaned = cls.extract_emotion(content)
+            if cleaned:
+                return emotion, cleaned
+        except Exception as exc:
+            # Never include request headers or runtime configuration here; the
+            # browser API key must not enter Workers Observability logs.
+            print(f"[LLMService] {provider} request failed: {type(exc).__name__}: {str(exc)[:240]}")
 
         return cls.local_fallback_reply(user_text)
 

--- a/docs/AI_SETTINGS.md
+++ b/docs/AI_SETTINGS.md
@@ -1,0 +1,47 @@
+# Browser AI settings
+
+NoriOS adds an **AI** section to the virtual **Settings** application without modifying the large compiled `NormalApp` bundle.
+
+## Settings
+
+The browser can override the server-side model configuration with:
+
+- Provider: OpenAI-compatible or Anthropic
+- Base URL
+- Model
+- API key
+- System prompt
+- Nori / character prompt
+- Temperature
+- Maximum output tokens
+
+The **Use browser AI configuration** switch is off by default. When it is off, Nori.Web keeps using the server's existing `OPENAI_*` configuration and local fallback behavior.
+
+## Browser persistence
+
+Non-secret preferences are stored under the namespaced `localStorage` key:
+
+```text
+nori.ai.settings.v1
+```
+
+The API key is safer by default:
+
+- **Remember API Key off**: the key is kept in `sessionStorage` under `nori.ai.api-key.v1` and disappears when the browser session ends.
+- **Remember API Key on**: the key is persisted in `localStorage` with the other settings.
+
+A persisted browser key can be read by JavaScript executing on the same origin. Do not enable persistent-key storage on a shared or untrusted browser profile.
+
+## Server transport and secret isolation
+
+Before the browser sends a player chat message, `public/nori-ai-settings.js` sends the active configuration over the verified Arcade `event` channel:
+
+```text
+nori.ai.config
+```
+
+The backend validates it and stores it in a Python `ContextVar` for the current WebSocket execution context. It is deliberately **not** stored in a cartridge state, runtime transition, world snapshot, or Durable Object storage.
+
+The acknowledgement contains only a redacted summary such as `hasApiKey`; it never returns the key itself. Provider errors also avoid logging request headers or configuration values.
+
+Browser overrides never inherit the server's `OPENAI_API_KEY`. This prevents a user-supplied Base URL from receiving the server's credential.

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,10 @@
     <link rel="modulepreload" crossorigin href="/assets/i18n-DtIC1LRi.js" />
     <link rel="modulepreload" crossorigin href="/assets/NormalApp-Cn6agT0F.js" />
     <script defer src="/cubism_sdk/Core/live2dcubismcore.js"></script>
+    <!-- Load the compatibility extension before the Vite application so its
+         WebSocket hook can attach per-browser AI configuration without
+         changing the shipped cartridge protocol. -->
+    <script src="/nori-ai-settings.js"></script>
     <!-- No model warmup here: dev-bypass preloads via preloadLive2DModel in
          main.tsx (fetch + decode + stage, strictly stronger than an HTTP
          warmer and not duplicated — fetch() does not coalesce identical

--- a/public/nori-ai-settings.js
+++ b/public/nori-ai-settings.js
@@ -1,0 +1,545 @@
+(() => {
+  "use strict";
+
+  const STORAGE_KEY = "nori.ai.settings.v1";
+  const SESSION_KEY = "nori.ai.api-key.v1";
+  const INSTALLED = Symbol("noriAiSettingsInstalled");
+  const wsFingerprints = new WeakMap();
+
+  const DEFAULTS = Object.freeze({
+    enabled: false,
+    provider: "openai-compatible",
+    baseUrl: "https://api.openai.com/v1",
+    model: "gpt-4o-mini",
+    apiKey: "",
+    rememberApiKey: false,
+    systemPrompt:
+      "You are Nori, the AI companion inside NoriOS. Be warm, concise, curious, and helpful. Reply in the user's language when practical. Avoid claiming actions you have not performed.",
+    characterPrompt: "",
+    temperature: 0.75,
+    maxTokens: 350,
+  });
+
+  function safeParse(value) {
+    try {
+      const parsed = JSON.parse(value);
+      return parsed && typeof parsed === "object" ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function safeStorage(storage, operation, ...args) {
+    try {
+      return storage[operation](...args);
+    } catch {
+      return null;
+    }
+  }
+
+  function clampNumber(value, fallback, min, max) {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.max(min, Math.min(max, number)) : fallback;
+  }
+
+  function normalize(settings) {
+    const source = settings && typeof settings === "object" ? settings : {};
+    const provider = source.provider === "anthropic" ? "anthropic" : "openai-compatible";
+    return {
+      enabled: source.enabled === true,
+      provider,
+      baseUrl: String(source.baseUrl || DEFAULTS.baseUrl).trim().slice(0, 1000),
+      model: String(source.model || DEFAULTS.model).trim().slice(0, 200),
+      apiKey: String(source.apiKey || "").trim().slice(0, 2048),
+      rememberApiKey: source.rememberApiKey === true,
+      systemPrompt: String(source.systemPrompt ?? DEFAULTS.systemPrompt).slice(0, 16000),
+      characterPrompt: String(source.characterPrompt || "").slice(0, 16000),
+      temperature: clampNumber(source.temperature, DEFAULTS.temperature, 0, 2),
+      maxTokens: Math.round(clampNumber(source.maxTokens, DEFAULTS.maxTokens, 32, 4096)),
+    };
+  }
+
+  function loadSettings() {
+    const persisted = safeParse(safeStorage(localStorage, "getItem", STORAGE_KEY) || "{}");
+    const sessionKey = safeStorage(sessionStorage, "getItem", SESSION_KEY) || "";
+    const apiKey = persisted.rememberApiKey ? persisted.apiKey || "" : sessionKey;
+    return normalize({ ...DEFAULTS, ...persisted, apiKey });
+  }
+
+  function saveSettings(input) {
+    const settings = normalize(input);
+    const persisted = { ...settings };
+    if (!settings.rememberApiKey) persisted.apiKey = "";
+    safeStorage(localStorage, "setItem", STORAGE_KEY, JSON.stringify(persisted));
+    if (settings.rememberApiKey) {
+      safeStorage(sessionStorage, "removeItem", SESSION_KEY);
+    } else if (settings.apiKey) {
+      safeStorage(sessionStorage, "setItem", SESSION_KEY, settings.apiKey);
+    } else {
+      safeStorage(sessionStorage, "removeItem", SESSION_KEY);
+    }
+    window.dispatchEvent(new CustomEvent("nori:ai-settings-changed", { detail: publicSettings(settings) }));
+    return settings;
+  }
+
+  function resetSettings() {
+    safeStorage(localStorage, "removeItem", STORAGE_KEY);
+    safeStorage(sessionStorage, "removeItem", SESSION_KEY);
+    const settings = normalize(DEFAULTS);
+    window.dispatchEvent(new CustomEvent("nori:ai-settings-changed", { detail: publicSettings(settings) }));
+    return settings;
+  }
+
+  function publicSettings(settings) {
+    return {
+      enabled: settings.enabled,
+      provider: settings.provider,
+      baseUrl: settings.baseUrl,
+      model: settings.model,
+      rememberApiKey: settings.rememberApiKey,
+      hasApiKey: Boolean(settings.apiKey),
+      systemPrompt: settings.systemPrompt,
+      characterPrompt: settings.characterPrompt,
+      temperature: settings.temperature,
+      maxTokens: settings.maxTokens,
+    };
+  }
+
+  function runtimePayload() {
+    const settings = loadSettings();
+    return {
+      enabled: settings.enabled,
+      provider: settings.provider,
+      baseUrl: settings.baseUrl,
+      model: settings.model,
+      apiKey: settings.apiKey,
+      systemPrompt: settings.systemPrompt,
+      characterPrompt: settings.characterPrompt,
+      temperature: settings.temperature,
+      maxTokens: settings.maxTokens,
+    };
+  }
+
+  function runtimeFingerprint(payload) {
+    // The fingerprint never leaves this page. Including the key prevents a
+    // changed key from reusing an older server-side runtime configuration.
+    return JSON.stringify(payload);
+  }
+
+  function isChatPlayerDispatch(message) {
+    return (
+      message &&
+      message.type === "dispatch" &&
+      message.cartridgeId === "chat" &&
+      message.actor === "player" &&
+      message.cmd &&
+      message.cmd.type === "playerMessage"
+    );
+  }
+
+  // The extension loads before the main Vite bundle. Intercept only outbound
+  // chat player dispatches and prepend a standard Arcade event carrying the
+  // ephemeral AI configuration. The config event itself is not a cartridge
+  // command and therefore never appears in runtime_transition payloads.
+  const nativeSend = WebSocket.prototype.send;
+  WebSocket.prototype.send = function patchedNoriSend(data) {
+    if (typeof data === "string") {
+      try {
+        const message = JSON.parse(data);
+        if (isChatPlayerDispatch(message)) {
+          const payload = runtimePayload();
+          const fingerprint = runtimeFingerprint(payload);
+          if (wsFingerprints.get(this) !== fingerprint) {
+            nativeSend.call(
+              this,
+              JSON.stringify({
+                type: "event",
+                worldId: message.worldId,
+                cartridgeId: "chat",
+                requestId: `ai-config-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+                channel: "nori.ai.config",
+                payload,
+              }),
+            );
+            wsFingerprints.set(this, fingerprint);
+          }
+        }
+      } catch {
+        // Preserve the shipped client's behavior for non-JSON frames.
+      }
+    }
+    return nativeSend.call(this, data);
+  };
+
+  function isChinese() {
+    const lang = String(document.documentElement.lang || navigator.language || "").toLowerCase();
+    return lang.startsWith("zh");
+  }
+
+  const TEXT = {
+    en: {
+      tab: "AI",
+      title: "AI Model & Prompts",
+      subtitle: "Stored in this browser and applied to Nori chat.",
+      enabled: "Use browser AI configuration",
+      enabledHint: "Off = keep using the server's configured model and credentials.",
+      provider: "Provider",
+      baseUrl: "Base URL",
+      model: "Model",
+      apiKey: "API Key",
+      rememberKey: "Remember API Key in this browser",
+      keyWarning: "Saved browser keys can be read by scripts running on this same origin. Leave this off on shared devices.",
+      systemPrompt: "System Prompt",
+      characterPrompt: "Nori / Character Prompt",
+      characterPlaceholder: "Optional additional personality, setting, style, or behavioral instructions…",
+      temperature: "Temperature",
+      maxTokens: "Max Tokens",
+      save: "Save",
+      saved: "Saved locally",
+      reset: "Restore defaults",
+      serverNote: "When browser override is disabled, the Worker keeps using its OPENAI_* configuration.",
+    },
+    zh: {
+      tab: "AI",
+      title: "AI 模型与提示词",
+      subtitle: "配置保存在当前浏览器，并应用到 Nori 对话。",
+      enabled: "使用浏览器 AI 配置",
+      enabledHint: "关闭时继续使用服务器中配置的模型与凭据。",
+      provider: "提供商",
+      baseUrl: "Base URL",
+      model: "模型",
+      apiKey: "API Key",
+      rememberKey: "在此浏览器记住 API Key",
+      keyWarning: "持久化到浏览器的 Key 可被同源页面脚本读取；在公用设备上请不要开启。",
+      systemPrompt: "System Prompt",
+      characterPrompt: "Nori / 角色提示词",
+      characterPlaceholder: "可选：补充人格、世界观、语气或行为要求……",
+      temperature: "Temperature",
+      maxTokens: "最大输出 Tokens",
+      save: "保存",
+      saved: "已保存到浏览器",
+      reset: "恢复默认",
+      serverNote: "浏览器覆盖关闭时，Worker 会继续使用服务器的 OPENAI_* 配置。",
+    },
+  };
+
+  function labels() {
+    return isChinese() ? TEXT.zh : TEXT.en;
+  }
+
+  function installStyles() {
+    if (document.getElementById("nori-ai-settings-style")) return;
+    const style = document.createElement("style");
+    style.id = "nori-ai-settings-style";
+    style.textContent = `
+      .nori-ai-settings-panel{flex:1;min-width:0;overflow:auto;padding:24px 28px;background:var(--background,transparent);color:inherit}
+      .nori-ai-settings-wrap{max-width:820px;margin:0 auto 36px}
+      .nori-ai-settings-head{margin-bottom:22px}
+      .nori-ai-settings-title{font-size:20px;font-weight:650;letter-spacing:-.01em;margin:0 0 5px}
+      .nori-ai-settings-subtitle{font-size:13px;opacity:.62;margin:0}
+      .nori-ai-card{border:1px solid color-mix(in srgb,currentColor 14%,transparent);border-radius:12px;padding:18px;background:color-mix(in srgb,currentColor 3%,transparent);margin-bottom:14px}
+      .nori-ai-row{display:grid;grid-template-columns:minmax(145px,190px) minmax(0,1fr);align-items:start;gap:14px;margin-bottom:15px}
+      .nori-ai-row:last-child{margin-bottom:0}
+      .nori-ai-label{font-size:13px;font-weight:600;padding-top:8px}
+      .nori-ai-hint{display:block;font-size:11px;line-height:1.5;opacity:.55;font-weight:400;margin-top:4px}
+      .nori-ai-input,.nori-ai-select,.nori-ai-textarea{box-sizing:border-box;width:100%;border:1px solid color-mix(in srgb,currentColor 18%,transparent);border-radius:8px;background:color-mix(in srgb,currentColor 5%,transparent);color:inherit;padding:8px 10px;font:inherit;font-size:13px;outline:none}
+      .nori-ai-input:focus,.nori-ai-select:focus,.nori-ai-textarea:focus{border-color:color-mix(in srgb,#65d9e8 75%,currentColor);box-shadow:0 0 0 2px color-mix(in srgb,#65d9e8 18%,transparent)}
+      .nori-ai-textarea{min-height:116px;resize:vertical;line-height:1.55}
+      .nori-ai-checkbox-line{display:flex;align-items:center;gap:9px;min-height:34px;font-size:13px}
+      .nori-ai-checkbox-line input{width:16px;height:16px;accent-color:#65d9e8}
+      .nori-ai-secret-wrap{display:flex;gap:8px}
+      .nori-ai-secret-wrap .nori-ai-input{flex:1}
+      .nori-ai-small-button,.nori-ai-button{border:1px solid color-mix(in srgb,currentColor 18%,transparent);border-radius:8px;background:color-mix(in srgb,currentColor 7%,transparent);color:inherit;padding:7px 12px;font:inherit;font-size:12px;cursor:pointer}
+      .nori-ai-button.primary{background:color-mix(in srgb,#65d9e8 22%,transparent);border-color:color-mix(in srgb,#65d9e8 48%,transparent)}
+      .nori-ai-button:hover,.nori-ai-small-button:hover{background:color-mix(in srgb,currentColor 11%,transparent)}
+      .nori-ai-warning{font-size:11px;line-height:1.55;color:#e7b65d;margin-top:7px}
+      .nori-ai-actions{display:flex;align-items:center;gap:10px;margin-top:18px}
+      .nori-ai-status{font-size:12px;opacity:0;transition:opacity .2s}
+      .nori-ai-status.visible{opacity:.7}
+      .nori-ai-tab{width:100%;border:0;background:transparent;color:inherit;cursor:pointer}
+      .nori-ai-tab.nori-ai-tab-active{background:color-mix(in srgb,#65d9e8 12%,transparent)!important;color:#65d9e8!important;font-weight:600}
+      @media(max-width:720px){.nori-ai-settings-panel{padding:18px}.nori-ai-row{grid-template-columns:1fr;gap:6px}.nori-ai-label{padding-top:0}}
+    `;
+    document.head.appendChild(style);
+  }
+
+  function field(tag, name, type) {
+    const element = document.createElement(tag);
+    element.dataset.field = name;
+    if (type) element.type = type;
+    element.className = tag === "textarea" ? "nori-ai-textarea" : tag === "select" ? "nori-ai-select" : "nori-ai-input";
+    return element;
+  }
+
+  function row(labelText, control, hintText = "") {
+    const root = document.createElement("div");
+    root.className = "nori-ai-row";
+    const label = document.createElement("div");
+    label.className = "nori-ai-label";
+    label.textContent = labelText;
+    if (hintText) {
+      const hint = document.createElement("span");
+      hint.className = "nori-ai-hint";
+      hint.textContent = hintText;
+      label.appendChild(hint);
+    }
+    root.append(label, control);
+    return root;
+  }
+
+  function checkbox(name, text) {
+    const line = document.createElement("label");
+    line.className = "nori-ai-checkbox-line";
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.dataset.field = name;
+    const caption = document.createElement("span");
+    caption.textContent = text;
+    line.append(input, caption);
+    return line;
+  }
+
+  function createPanel() {
+    const t = labels();
+    const panel = document.createElement("section");
+    panel.className = "nori-ai-settings-panel";
+    panel.hidden = true;
+    panel.dataset.noriAiPanel = "1";
+
+    const wrap = document.createElement("div");
+    wrap.className = "nori-ai-settings-wrap";
+    const head = document.createElement("div");
+    head.className = "nori-ai-settings-head";
+    const title = document.createElement("h2");
+    title.className = "nori-ai-settings-title";
+    title.textContent = t.title;
+    const subtitle = document.createElement("p");
+    subtitle.className = "nori-ai-settings-subtitle";
+    subtitle.textContent = t.subtitle;
+    head.append(title, subtitle);
+
+    const card = document.createElement("div");
+    card.className = "nori-ai-card";
+
+    const enabled = checkbox("enabled", t.enabled);
+    card.append(row(t.enabled, enabled, t.enabledHint));
+
+    const provider = field("select", "provider");
+    provider.append(new Option("OpenAI Compatible", "openai-compatible"), new Option("Anthropic", "anthropic"));
+    card.append(row(t.provider, provider));
+
+    const baseUrl = field("input", "baseUrl", "url");
+    baseUrl.autocomplete = "off";
+    baseUrl.spellcheck = false;
+    card.append(row(t.baseUrl, baseUrl));
+
+    const model = field("input", "model", "text");
+    model.autocomplete = "off";
+    model.spellcheck = false;
+    card.append(row(t.model, model));
+
+    const secretWrap = document.createElement("div");
+    secretWrap.className = "nori-ai-secret-wrap";
+    const apiKey = field("input", "apiKey", "password");
+    apiKey.autocomplete = "off";
+    apiKey.spellcheck = false;
+    const reveal = document.createElement("button");
+    reveal.type = "button";
+    reveal.className = "nori-ai-small-button";
+    reveal.textContent = "👁";
+    reveal.addEventListener("click", () => {
+      apiKey.type = apiKey.type === "password" ? "text" : "password";
+    });
+    secretWrap.append(apiKey, reveal);
+    card.append(row(t.apiKey, secretWrap));
+
+    const remember = checkbox("rememberApiKey", t.rememberKey);
+    const rememberBox = document.createElement("div");
+    rememberBox.append(remember);
+    const warning = document.createElement("div");
+    warning.className = "nori-ai-warning";
+    warning.textContent = t.keyWarning;
+    rememberBox.append(warning);
+    card.append(row(t.rememberKey, rememberBox));
+
+    const systemPrompt = field("textarea", "systemPrompt");
+    systemPrompt.spellcheck = false;
+    card.append(row(t.systemPrompt, systemPrompt));
+
+    const characterPrompt = field("textarea", "characterPrompt");
+    characterPrompt.placeholder = t.characterPlaceholder;
+    characterPrompt.spellcheck = false;
+    card.append(row(t.characterPrompt, characterPrompt));
+
+    const temperature = field("input", "temperature", "number");
+    temperature.min = "0";
+    temperature.max = "2";
+    temperature.step = "0.05";
+    card.append(row(t.temperature, temperature));
+
+    const maxTokens = field("input", "maxTokens", "number");
+    maxTokens.min = "32";
+    maxTokens.max = "4096";
+    maxTokens.step = "1";
+    card.append(row(t.maxTokens, maxTokens));
+
+    const serverNote = document.createElement("div");
+    serverNote.className = "nori-ai-hint";
+    serverNote.textContent = t.serverNote;
+
+    const actions = document.createElement("div");
+    actions.className = "nori-ai-actions";
+    const save = document.createElement("button");
+    save.type = "button";
+    save.className = "nori-ai-button primary";
+    save.textContent = t.save;
+    const reset = document.createElement("button");
+    reset.type = "button";
+    reset.className = "nori-ai-button";
+    reset.textContent = t.reset;
+    const status = document.createElement("span");
+    status.className = "nori-ai-status";
+    status.textContent = t.saved;
+    actions.append(save, reset, status);
+
+    wrap.append(head, card, serverNote, actions);
+    panel.append(wrap);
+
+    function fill(settings) {
+      const value = normalize(settings);
+      for (const element of panel.querySelectorAll("[data-field]")) {
+        const key = element.dataset.field;
+        if (element.type === "checkbox") element.checked = Boolean(value[key]);
+        else element.value = value[key] ?? "";
+      }
+    }
+
+    function read() {
+      const current = loadSettings();
+      for (const element of panel.querySelectorAll("[data-field]")) {
+        const key = element.dataset.field;
+        current[key] = element.type === "checkbox" ? element.checked : element.value;
+      }
+      return normalize(current);
+    }
+
+    provider.addEventListener("change", () => {
+      const current = String(baseUrl.value || "").trim();
+      if (
+        !current ||
+        current === "https://api.openai.com/v1" ||
+        current === "https://api.anthropic.com/v1"
+      ) {
+        baseUrl.value = provider.value === "anthropic" ? "https://api.anthropic.com/v1" : "https://api.openai.com/v1";
+      }
+      if (!String(model.value || "").trim() || model.value === "gpt-4o-mini") {
+        model.value = provider.value === "anthropic" ? "claude-3-5-sonnet-20241022" : "gpt-4o-mini";
+      }
+    });
+
+    save.addEventListener("click", () => {
+      fill(saveSettings(read()));
+      status.classList.add("visible");
+      window.setTimeout(() => status.classList.remove("visible"), 1600);
+    });
+
+    reset.addEventListener("click", () => {
+      fill(resetSettings());
+      status.classList.add("visible");
+      window.setTimeout(() => status.classList.remove("visible"), 1600);
+    });
+
+    fill(loadSettings());
+    panel.refresh = () => fill(loadSettings());
+    return panel;
+  }
+
+  function looksLikeSettingsNav(nav) {
+    const texts = [...nav.querySelectorAll("button")].map((button) => button.textContent.trim());
+    const includesAny = (choices) => choices.some((choice) => texts.includes(choice));
+    return (
+      includesAny(["Sound", "声音"]) &&
+      includesAny(["Graphics", "显示效果"]) &&
+      includesAny(["Network", "网络"]) &&
+      includesAny(["System", "系统"])
+    );
+  }
+
+  function installIntoNav(nav) {
+    if (nav[INSTALLED] || !looksLikeSettingsNav(nav)) return;
+    const sidebar = nav.parentElement;
+    const shell = sidebar?.parentElement;
+    if (!sidebar || !shell) return;
+    nav[INSTALLED] = true;
+
+    const t = labels();
+    const originalButtons = [...nav.querySelectorAll("button")];
+    const aiButton = document.createElement("button");
+    aiButton.type = "button";
+    aiButton.className =
+      originalButtons[0]?.className ||
+      "flex items-center gap-2.5 rounded-md px-2.5 py-1.5 text-sm transition-colors text-muted-foreground hover:bg-muted hover:text-foreground";
+    aiButton.classList.add("nori-ai-tab");
+    const icon = document.createElement("span");
+    icon.textContent = "✦";
+    icon.style.width = "1rem";
+    icon.style.textAlign = "center";
+    const text = document.createElement("span");
+    text.textContent = t.tab;
+    aiButton.append(icon, text);
+    nav.appendChild(aiButton);
+
+    const panel = createPanel();
+    shell.appendChild(panel);
+    const hidden = new Map();
+
+    function showAI() {
+      for (const child of [...shell.children]) {
+        if (child === sidebar || child === panel) continue;
+        if (!hidden.has(child)) hidden.set(child, child.style.display);
+        child.style.display = "none";
+      }
+      panel.hidden = false;
+      panel.style.display = "block";
+      aiButton.classList.add("nori-ai-tab-active");
+      panel.refresh?.();
+    }
+
+    function restore() {
+      panel.hidden = true;
+      panel.style.display = "none";
+      aiButton.classList.remove("nori-ai-tab-active");
+      for (const [child, display] of hidden) {
+        if (child.isConnected) child.style.display = display;
+      }
+      hidden.clear();
+    }
+
+    aiButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      showAI();
+    });
+    for (const button of originalButtons) button.addEventListener("click", restore, { capture: true });
+  }
+
+  function scanSettings() {
+    for (const nav of document.querySelectorAll("nav")) installIntoNav(nav);
+  }
+
+  installStyles();
+  const observer = new MutationObserver(scanSettings);
+  observer.observe(document.documentElement, { subtree: true, childList: true });
+  document.addEventListener("DOMContentLoaded", scanSettings, { once: true });
+  window.addEventListener("storage", (event) => {
+    if (event.key === STORAGE_KEY) scanSettings();
+  });
+  scanSettings();
+
+  // Small public API for debugging/automation without exposing the key through
+  // console output. get() intentionally returns a redacted shape.
+  window.NoriAISettings = Object.freeze({
+    get: () => publicSettings(loadSettings()),
+    save: (settings) => publicSettings(saveSettings({ ...loadSettings(), ...settings })),
+    reset: () => publicSettings(resetSettings()),
+  });
+})();

--- a/server.py
+++ b/server.py
@@ -11,8 +11,10 @@ from fastapi.middleware.gzip import GZipMiddleware
 
 from backend.api import api_router, register_mimetypes, static_router
 from backend.core.config import DEBUG, HOST, PORT
+from backend.services.ai_event_bridge import install_ai_event_bridge
 
 register_mimetypes()
+install_ai_event_bridge()
 
 
 def create_app(*, include_static: bool = True) -> FastAPI:

--- a/tests/test_ai_runtime_settings.py
+++ b/tests/test_ai_runtime_settings.py
@@ -100,12 +100,16 @@ async def main() -> None:
     assert "Keep Nori curious and concise." in captured["system_prompt"]
     assert "NoriOS rendering contract" in captured["system_prompt"]
 
-    # Static integration checks: the compatibility extension loads before the
-    # app and uses browser persistence plus the non-stateful config event.
+    # Static integration checks: the compatibility extension executes before
+    # the main module script. The Vite modulepreload link may appear earlier
+    # and is intentionally ignored because it does not execute application JS.
     index_html = (ROOT / "public" / "index.html").read_text(encoding="utf-8")
     client_js = (ROOT / "public" / "nori-ai-settings.js").read_text(encoding="utf-8")
-    assert '<script src="/nori-ai-settings.js"></script>' in index_html
-    assert index_html.index('/nori-ai-settings.js') < index_html.index('/assets/index-CyHAbkO5.js')
+    ai_script = '<script src="/nori-ai-settings.js"></script>'
+    app_script = '<script type="module" crossorigin src="/assets/index-CyHAbkO5.js"></script>'
+    assert ai_script in index_html
+    assert app_script in index_html
+    assert index_html.index(ai_script) < index_html.index(app_script)
     assert "localStorage" in client_js
     assert "sessionStorage" in client_js
     assert 'channel: "nori.ai.config"' in client_js

--- a/tests/test_ai_runtime_settings.py
+++ b/tests/test_ai_runtime_settings.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from backend.services.ai_event_bridge import install_ai_event_bridge
+from backend.services.ai_runtime_config import (
+    clear_runtime_ai_config,
+    get_runtime_ai_config,
+    public_runtime_ai_summary,
+    sanitize_runtime_ai_config,
+)
+from backend.services.event_dispatcher import EventDispatcher
+from backend.services.llm_service import LLMService
+
+
+class DummyWorld:
+    world_id = "test-world"
+
+
+async def main() -> None:
+    secret = "super-secret-browser-key"
+    raw = {
+        "enabled": True,
+        "provider": "openai-compatible",
+        "baseUrl": "https://example.test/v1/",
+        "model": "custom-model",
+        "apiKey": secret,
+        "systemPrompt": "Custom system prompt",
+        "characterPrompt": "Keep Nori curious and concise.",
+        "temperature": 9,
+        "maxTokens": 999999,
+    }
+
+    sanitized = sanitize_runtime_ai_config(raw)
+    assert sanitized["enabled"] is True
+    assert sanitized["provider"] == "openai-compatible"
+    assert sanitized["baseUrl"] == "https://example.test/v1"
+    assert sanitized["temperature"] == 2.0
+    assert sanitized["maxTokens"] == 4096
+
+    # URLs containing inline credentials are rejected. Credentials belong only
+    # in the dedicated secret field, which keeps them out of request URLs/logs.
+    bad_url = sanitize_runtime_ai_config({
+        **raw,
+        "baseUrl": "https://user:password@example.test/v1",
+    })
+    assert bad_url["baseUrl"] == ""
+
+    summary = public_runtime_ai_summary(sanitized)
+    assert "apiKey" not in summary
+    assert secret not in repr(summary)
+    assert summary["hasApiKey"] is True
+
+    # The existing generic Arcade event channel carries the configuration
+    # without putting it in cartridge state or runtime_transition objects.
+    install_ai_event_bridge()
+    dispatcher = EventDispatcher(DummyWorld())
+    response = await dispatcher.handle_event(
+        {
+            "type": "event",
+            "channel": "nori.ai.config",
+            "requestId": "settings-test",
+            "payload": raw,
+        }
+    )
+    assert response["channel"] == "nori.ai.config.result"
+    assert response["requestId"] == "settings-test"
+    assert "apiKey" not in response["payload"]
+    assert secret not in repr(response)
+    assert get_runtime_ai_config()["apiKey"] == secret
+
+    # Prove that model, endpoint and both prompt fields actually reach the
+    # provider call, while preserving NoriOS's emotion-rendering contract.
+    captured: dict = {}
+    original_openai = LLMService.__dict__["_openai_compatible_reply"]
+
+    async def fake_openai(cls, **kwargs):
+        captured.update(kwargs)
+        return "[emotion:happy] configured reply"
+
+    LLMService._openai_compatible_reply = classmethod(fake_openai)
+    try:
+        emotion, reply = await LLMService.generate_reply("hello", [])
+    finally:
+        LLMService._openai_compatible_reply = original_openai
+
+    assert emotion == "happy"
+    assert reply == "configured reply"
+    assert captured["base_url"] == "https://example.test/v1"
+    assert captured["model"] == "custom-model"
+    assert captured["api_key"] == secret
+    assert captured["temperature"] == 2.0
+    assert captured["max_tokens"] == 4096
+    assert "Custom system prompt" in captured["system_prompt"]
+    assert "Keep Nori curious and concise." in captured["system_prompt"]
+    assert "NoriOS rendering contract" in captured["system_prompt"]
+
+    # Static integration checks: the compatibility extension loads before the
+    # app and uses browser persistence plus the non-stateful config event.
+    index_html = (ROOT / "public" / "index.html").read_text(encoding="utf-8")
+    client_js = (ROOT / "public" / "nori-ai-settings.js").read_text(encoding="utf-8")
+    assert '<script src="/nori-ai-settings.js"></script>' in index_html
+    assert index_html.index('/nori-ai-settings.js') < index_html.index('/assets/index-CyHAbkO5.js')
+    assert "localStorage" in client_js
+    assert "sessionStorage" in client_js
+    assert 'channel: "nori.ai.config"' in client_js
+    assert "rememberApiKey" in client_js
+    assert "apiKey" in client_js
+
+    clear_runtime_ai_config()
+    assert get_runtime_ai_config() == {}
+    print("[ok] browser AI settings are persistent, effective, and keep API keys out of public state")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Adds the missing AI model and prompt configuration to NoriOS's virtual **Settings** application and persists user preferences in the browser.

### Settings → AI

Adds configuration for:

- browser AI override on/off
- provider: OpenAI-compatible or Anthropic
- Base URL
- model
- API key
- optional persistent API-key storage
- system prompt
- Nori / character prompt
- temperature
- maximum output tokens

The existing compiled `NormalApp` bundle is left untouched. A small compatibility extension (`public/nori-ai-settings.js`) detects the existing Settings window and injects the AI section in place, so the change remains maintainable even though the original frontend source is not present in this repository.

### Browser persistence

- model, provider, endpoint, prompts, and sampling settings persist in namespaced `localStorage`
- API key defaults to `sessionStorage` only
- the key moves to persistent `localStorage` only when the user explicitly enables **Remember API Key in this browser**
- the UI warns that same-origin scripts can read a browser-persisted key

### Backend integration and secret isolation

The browser sends the active AI configuration through the existing non-cartridge Arcade event channel `nori.ai.config` before the next player chat dispatch.

The backend validates it and keeps it in a `ContextVar` for the current WebSocket execution context. The configuration is deliberately not stored in cartridge state, runtime transitions, world snapshots, or Durable Object storage.

The acknowledgement is redacted and never contains the API key. Browser overrides also never inherit the server's `OPENAI_API_KEY`, preventing a custom browser-provided Base URL from receiving a server credential.

When browser override is disabled, the existing server-side `OPENAI_*` configuration and local fallback behavior remain unchanged.

### Prompt behavior

Custom system/character prompts are applied to provider requests while retaining the small NoriOS emotion-tag rendering contract required by the Live2D presentation layer.

### Validation

CI now checks:

- browser AI config validation and clamping
- secret exclusion from public acknowledgements
- model, endpoint, API key, prompt, temperature and max-token propagation to the provider call
- browser persistence integration markers
- JavaScript syntax with `node --check`
- existing Python/Cloudflare tests and the Free-plan Worker bundle-size guard

See `docs/AI_SETTINGS.md` for the storage/security model.