### PR TITLE
chore: sync Cloudflare dashboard routing config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -33,11 +33,21 @@
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
+    "redact_query_string": false,
     "traces": {
       "enabled": true,
       "head_sampling_rate": 1
     }
   },
+  "placement": {
+    "mode": "smart"
+  },
+  "routes": [
+    {
+      "pattern": "nori-expermintal.088092111.xyz",
+      "custom_domain": true
+    }
+  ],
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",


### PR DESCRIPTION
Syncs the Cloudflare configuration currently set through the Dashboard into `wrangler.jsonc` so future Wrangler deploys do not remove it.

Preserves:
- custom domain `nori-expermintal.088092111.xyz`
- Smart Placement (`placement.mode = "smart"`)
- `observability.redact_query_string = false`

Existing Durable Object, R2, Static Assets, Logs and Traces configuration is unchanged.

Follow-up note: Workers.dev and Preview URLs are being preserved in a separate PR because #10 was already merged when that additional Dashboard difference surfaced.