### PR TITLE
chore: preserve Workers.dev and preview URLs

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,8 @@
   "main": "cloudflare/entry.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
+  "workers_dev": true,
+  "preview_urls": true,
   "base_dir": "./cloudflare",
   "find_additional_modules": true,
   "rules": [


### PR DESCRIPTION
Keeps the remaining Cloudflare Dashboard routing flags in `wrangler.jsonc` so local Wrangler deploys no longer try to disable them.

Adds:
- `workers_dev: true`
- `preview_urls: true`

The custom domain, Smart Placement, Observability, Durable Object, R2 and Static Assets configuration is unchanged.