### PR TITLE
fix: deploy Workers Builds in CI mode

### DIFF
--- a/docs/CLOUDFLARE_BUILDS.md
+++ b/docs/CLOUDFLARE_BUILDS.md
@@ -10,12 +10,13 @@ production deploy entrypoint.
 Cloudflare Workers Builds does not automatically honor Wrangler Custom Builds.
 Nori.Web requires `scripts/prepare_cloudflare_runtime.py` to stage the Python
 Worker runtime before deployment, so the wrapper runs that preparation
-explicitly and then invokes `pywrangler deploy --yes`.
+explicitly and then invokes `pywrangler deploy`.
 
-`--yes` is deliberate: Workers Builds is non-interactive, while Cloudflare may
-report harmless differences between source configuration and Dashboard-expanded
-metadata (for example route metadata). A production build must never stop waiting
-for a confirmation prompt.
+The wrapper forces `CI=true` for the final Worker deployment. Wrangler uses its
+non-interactive fallback for confirmation prompts in CI, including harmless
+Dashboard-vs-source metadata differences. Do not add `--yes` to the deploy
+command: Wrangler 4.127 rejects that flag when a Wrangler configuration file is
+already present.
 
 The same wrapper also synchronizes the private R2 live-world layout. It compares
 `runtime/live/source-fingerprint.txt` with a fingerprint derived from both:
@@ -60,8 +61,8 @@ The Workers API exposes `observability.redact_query_string`, but Wrangler
 4.127's `wrangler.jsonc` schema does not currently accept that field. It is
 therefore intentionally not committed to this repository. If the Dashboard
 shows `redact_query_string: false` as remote-only metadata, leave it in the
-Dashboard; the CI deploy wrapper's non-interactive confirmation handles that
-metadata difference.
+Dashboard; Wrangler's CI fallback handles that metadata difference without an
+interactive prompt.
 
 GitHub Actions fails if Wrangler reports `Unexpected fields found`, preventing
 unsupported Dashboard/API fields from silently creeping back into

--- a/scripts/cloudflare_builds_deploy.py
+++ b/scripts/cloudflare_builds_deploy.py
@@ -26,7 +26,13 @@ R2_MARKER_KEY = "runtime/live/source-fingerprint.txt"
 FINGERPRINT_VERSION = "v1"
 
 
-def _run(command: list[str], *, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess[str]:
+def _run(
+    command: list[str],
+    *,
+    check: bool = True,
+    capture: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     printable = " ".join(command)
     print(f"+ {printable}")
     return subprocess.run(
@@ -36,6 +42,7 @@ def _run(command: list[str], *, check: bool = True, capture: bool = False) -> su
         text=True,
         stdout=subprocess.PIPE if capture else None,
         stderr=subprocess.PIPE if capture else None,
+        env=env,
     )
 
 
@@ -139,10 +146,13 @@ def prepare_runtime() -> None:
 
 
 def deploy_worker(base: list[str]) -> None:
-    # Workers Builds is non-interactive. --yes prevents a harmless Dashboard-vs-
-    # source metadata prompt (for example expanded route metadata) from blocking
-    # the production build.
-    _run([*base, "deploy", "--yes"])
+    # Wrangler 4.127 rejects `wrangler deploy --yes` when a Wrangler config file
+    # already exists. Workers Builds is a CI environment, so force CI mode and
+    # let Wrangler use its documented non-interactive fallback for confirmation
+    # prompts while keeping the deploy command itself standard.
+    deploy_env = os.environ.copy()
+    deploy_env["CI"] = "true"
+    _run([*base, "deploy"], env=deploy_env)
 
 
 def main() -> None:

--- a/tests/test_cloudflare_builds_deploy.py
+++ b/tests/test_cloudflare_builds_deploy.py
@@ -47,19 +47,30 @@ def main() -> None:
         module.SOURCE_PACK = original_source
         module.LIVE_PACK_TOOL = original_tool
 
-    # Production deploys must never wait for an interactive Dashboard-vs-source
-    # configuration confirmation inside Workers Builds.
-    calls: list[list[str]] = []
+    # Wrangler 4.127 rejects `deploy --yes` for configured Workers. Production
+    # deploys instead force CI mode, which lets Wrangler use its non-interactive
+    # fallback for any Dashboard-vs-source confirmation prompts.
+    calls: list[tuple[list[str], dict[str, object]]] = []
     original_run = module._run
     try:
-        module._run = lambda command, **kwargs: calls.append(list(command))
+        def fake_run(command, **kwargs):
+            calls.append((list(command), dict(kwargs)))
+
+        module._run = fake_run
         module.deploy_worker(["pywrangler"])
     finally:
         module._run = original_run
-    assert calls == [["pywrangler", "deploy", "--yes"]]
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command == ["pywrangler", "deploy"]
+    assert "--yes" not in command
+    deploy_env = kwargs.get("env")
+    assert isinstance(deploy_env, dict)
+    assert deploy_env.get("CI") == "true"
 
     print(
-        "[ok] Workers Builds deploy fingerprint tracks world data/layout and deploys non-interactively"
+        "[ok] Workers Builds deploy fingerprint tracks world data/layout and deploys in CI mode"
     )
 
 


### PR DESCRIPTION
Fixes the first Cloudflare Workers Build failure caused by passing unsupported `--yes` to Wrangler 4.127.

Changes:
- remove `--yes` from the production deploy command
- force `CI=true` for the final `pywrangler deploy` subprocess so Wrangler uses its non-interactive fallback for Dashboard-vs-source confirmation prompts
- update the regression test to assert `--yes` is absent and `CI=true` is present
- update the Workers Builds documentation

The first failed production build already uploaded the 38 live-world R2 objects and wrote `runtime/live/source-fingerprint.txt`, so the next build should skip the live-pack upload when the fingerprint matches.