### PR TITLE
fix: suppress blocked perf telemetry before NoriOS bootstrap

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -51,6 +51,12 @@ jobs:
       - name: Verify browser AI settings JavaScript
         run: node --check public/nori-ai-settings.js
 
+      - name: Verify browser runtime shim
+        run: uv run python tests/test_browser_runtime_shims.py
+
+      - name: Verify browser runtime shim JavaScript
+        run: node --check public/nori-runtime-shims.js
+
       - name: Compile Python sources
         run: uv run python -m compileall -q backend scripts server.py worker.py
 

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,9 @@
     <link rel="modulepreload" crossorigin href="/assets/i18n-DtIC1LRi.js" />
     <link rel="modulepreload" crossorigin href="/assets/NormalApp-Cn6agT0F.js" />
     <script defer src="/cubism_sdk/Core/live2dcubismcore.js"></script>
+    <!-- Keep optional debug telemetry local so privacy/ad-blocking extensions
+         do not create ERR_BLOCKED_BY_CLIENT noise for the shipped bundle. -->
+    <script src="/nori-runtime-shims.js"></script>
     <!-- Load the compatibility extension before the Vite application so its
          WebSocket hook can attach per-browser AI configuration without
          changing the shipped cartridge protocol. -->

--- a/public/nori-runtime-shims.js
+++ b/public/nori-runtime-shims.js
@@ -1,0 +1,35 @@
+(() => {
+  "use strict";
+
+  // The shipped NoriOS bundle reports optional performance vitals to the
+  // original os.inori.ai debug endpoint. Privacy/ad-blocking extensions often
+  // classify that endpoint as telemetry and block it, which creates noisy
+  // ERR_BLOCKED_BY_CLIENT console errors even though the application itself is
+  // healthy. Keep that optional diagnostic local instead of touching the
+  // network. No application API, Arcade request, or asset request is matched.
+  const isPerfVitalsUrl = (value) => {
+    try {
+      const raw = value instanceof Request ? value.url : String(value || "");
+      const url = new URL(raw, window.location.href);
+      return url.pathname === "/api/debug/perf-vitals";
+    } catch {
+      return false;
+    }
+  };
+
+  const nativeFetch = window.fetch.bind(window);
+  window.fetch = function noriFetch(input, init) {
+    if (isPerfVitalsUrl(input)) {
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }
+    return nativeFetch(input, init);
+  };
+
+  if (typeof navigator.sendBeacon === "function") {
+    const nativeSendBeacon = navigator.sendBeacon.bind(navigator);
+    navigator.sendBeacon = function noriSendBeacon(url, data) {
+      if (isPerfVitalsUrl(url)) return true;
+      return nativeSendBeacon(url, data);
+    };
+  }
+})();

--- a/tests/test_browser_runtime_shims.py
+++ b/tests/test_browser_runtime_shims.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+INDEX = (ROOT / "public" / "index.html").read_text(encoding="utf-8")
+SHIM = (ROOT / "public" / "nori-runtime-shims.js").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    shim_script = '<script src="/nori-runtime-shims.js"></script>'
+    app_script = '<script type="module" crossorigin src="/assets/index-CyHAbkO5.js"></script>'
+    assert shim_script in INDEX
+    assert app_script in INDEX
+    assert INDEX.index(shim_script) < INDEX.index(app_script)
+
+    assert 'url.pathname === "/api/debug/perf-vitals"' in SHIM
+    assert "window.fetch = function noriFetch" in SHIM
+    assert "navigator.sendBeacon = function noriSendBeacon" in SHIM
+
+    # This shim must stay scoped to optional telemetry. Arcade transport and
+    # application APIs must remain untouched.
+    assert "WebSocket.prototype" not in SHIM
+    assert "/api/arcade" not in SHIM
+
+    print("[ok] browser runtime shim suppresses only optional perf-vitals telemetry")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Suppresses the shipped frontend's optional `/api/debug/perf-vitals` telemetry locally before the Vite bundle starts, preventing privacy/ad-blocking extensions from producing noisy `ERR_BLOCKED_BY_CLIENT` console errors.

### Scope

- adds `public/nori-runtime-shims.js`
- intercepts only `/api/debug/perf-vitals` for `fetch()` and `navigator.sendBeacon()` and returns a local success
- loads the shim before the shipped application bundle
- does not patch WebSocket, Arcade APIs, Live2D, assets, or other application traffic
- adds Python/source-order and JavaScript syntax checks to CI

### Arcade WebSocket note

The current WebSocket failures are being evaluated separately because the Cloudflare account has already exhausted its daily Durable Objects duration allowance. On Workers Free, further operations of the exhausted type fail until the daily quota resets at 00:00 UTC, so the browser cannot currently distinguish a quota rejection from a transport/handshake regression. The Hibernation path will be retested after the quota reset before making additional production transport changes.