### PR TITLE
fix: use production getWebSockets API in hibernating DO

### DIFF
--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -4,8 +4,55 @@ Wrangler's build hook populates this directory with the current Nori.Web
 runtime before each dev/deploy invocation. Keeping the module root isolated
 prevents tests, scraper tools, frontend binaries, and local virtual
 environments from being counted against the Worker script-size limit.
+
+Cloudflare's DurableObjectState WebSocket enumeration API is exposed as
+``getWebSockets`` by the production runtime. Some Python-facing documentation
+and SDK surfaces have also used ``get_websockets``. Keep the compatibility
+bridge here so the hibernation runtime does not depend on one spelling.
 """
 
-from worker_runtime import Default, NoriArcadeSession
+import worker_runtime as _runtime
+
+Default = _runtime.Default
+
+
+def _runtime_websockets(ctx):
+    getter = getattr(ctx, "getWebSockets", None)
+    if callable(getter):
+        return getter()
+
+    # Compatibility fallback for Python SDK/runtime variants that expose a
+    # snake_case alias.
+    getter = getattr(ctx, "get_websockets", None)
+    if callable(getter):
+        return getter()
+
+    raise AttributeError(
+        "DurableObjectState exposes neither getWebSockets nor get_websockets"
+    )
+
+
+class NoriArcadeSession(_runtime.NoriArcadeSession):
+    """Runtime-compatible hibernating Arcade Durable Object."""
+
+    def _refresh_world_clients(self, world) -> None:
+        main_clients = set()
+        media_clients = set()
+        for websocket in _runtime_websockets(self.ctx):
+            attachment = _runtime._socket_attachment(websocket)
+            if attachment.get("userId") != world.owner_id:
+                continue
+            socket_id = attachment.get("socketId")
+            if not isinstance(socket_id, str) or not socket_id:
+                continue
+            role = attachment.get("role")
+            adapter = _runtime._HibernatingSocketAdapter(websocket, socket_id)
+            if role == "main":
+                main_clients.add(adapter)
+            elif role == "media" and attachment.get("worldId") == world.world_id:
+                media_clients.add(adapter)
+        world.clients = main_clients
+        world.media_clients = media_clients
+
 
 __all__ = ["Default", "NoriArcadeSession"]

--- a/tests/test_durable_object_hibernation.py
+++ b/tests/test_durable_object_hibernation.py
@@ -4,14 +4,25 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 WORKER = (ROOT / "worker.py").read_text(encoding="utf-8")
+ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
 
 
 def main() -> None:
     assert "self.ctx.acceptWebSocket(server)" in WORKER
     assert "async def webSocketMessage" in WORKER
-    assert "self.ctx.get_websockets()" in WORKER
     assert "serializeAttachment" in WORKER
     assert "deserializeAttachment" in WORKER
+
+    # The production Workers runtime exposes DurableObjectState.getWebSockets().
+    # Keep a snake_case fallback for Python SDK/runtime variants, but the runtime
+    # bridge must prefer the camelCase method that production actually provides.
+    assert 'getattr(ctx, "getWebSockets", None)' in ENTRY
+    assert 'getattr(ctx, "get_websockets", None)' in ENTRY
+    assert ENTRY.index('getattr(ctx, "getWebSockets", None)') < ENTRY.index(
+        'getattr(ctx, "get_websockets", None)'
+    )
+    assert "class NoriArcadeSession(_runtime.NoriArcadeSession)" in ENTRY
+    assert "def _refresh_world_clients" in ENTRY
 
     # A legacy ASGI WebSocket receive loop pins the Durable Object in memory for
     # the full browser connection and defeats hibernation.
@@ -28,7 +39,7 @@ def main() -> None:
     assert 'if key != "apiKey"' in WORKER
     assert '_DO_AI_CONFIG_KEY = "nori:ai-public:v1"' in WORKER
 
-    print("[ok] Arcade Durable Object uses hibernatable user-scoped WebSockets")
+    print("[ok] Arcade Durable Object uses runtime-compatible hibernating WebSockets")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the production Hibernation runtime error:

`[arcade] hibernation message error: get_websockets`

### Cause

The deployed Cloudflare DurableObjectState exposes the Hibernation enumeration method as `getWebSockets()`. The existing runtime path called `get_websockets()`, and the source guard incorrectly asserted that spelling, so CI protected the wrong API name.

### Fix

- wrap the exported `NoriArcadeSession` in `cloudflare/entry.py`
- override only `_refresh_world_clients()`
- prefer production `ctx.getWebSockets()`
- retain `ctx.get_websockets()` as a compatibility fallback for alternate Python SDK/runtime surfaces
- update the Hibernation source guard so CI now protects the real production API bridge

No world-state, R2, AI configuration, WebSocket attachment, or Hibernation lifecycle behavior is otherwise changed.

The observed `hibernatableWebSocket` span with ~1 ms CPU / ~2 ms wall confirms that Hibernation itself is active; this PR fixes the application-layer connection reconstruction step after wake.