### PR TITLE
perf: reduce Durable Object wake and snapshot overhead

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Verify Durable Object hibernation source path
         run: uv run python tests/test_durable_object_hibernation.py
 
+      - name: Verify Durable Object runtime efficiency
+        run: uv run python tests/test_do_runtime_efficiency.py
+
       - name: Verify Workers Builds deploy wrapper
         run: uv run python tests/test_cloudflare_builds_deploy.py
 

--- a/backend/session/world.py
+++ b/backend/session/world.py
@@ -7,9 +7,12 @@ import json
 import secrets
 import time
 import uuid
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Set, Tuple
 
-from fastapi import WebSocket
+if TYPE_CHECKING:
+    from fastapi import WebSocket
+else:
+    WebSocket = Any
 
 from ..cartridges.base import BaseCartridge, CommandRejected
 from ..cartridges.chat import ChatCartridge

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -11,6 +11,8 @@ and SDK surfaces have also used ``get_websockets``. Keep the compatibility
 bridge here so the hibernation runtime does not depend on one spelling.
 """
 
+import json
+
 import worker_runtime as _runtime
 
 Default = _runtime.Default
@@ -33,7 +35,46 @@ def _runtime_websockets(ctx):
 
 
 class NoriArcadeSession(_runtime.NoriArcadeSession):
-    """Runtime-compatible hibernating Arcade Durable Object."""
+    """Runtime-compatible and persistence-efficient Arcade Durable Object."""
+
+    def __init__(self, ctx, env):
+        super().__init__(ctx, env)
+        self._persisted_world_snapshot: str | None = None
+
+    async def _load_world(self, user_id: str):
+        world = self.manager.worlds_by_user.get(user_id)
+        if world is not None:
+            return world
+
+        async with self._world_load_lock:
+            world = self.manager.worlds_by_user.get(user_id)
+            if world is not None:
+                return world
+
+            if not await _runtime.live_pack.ensure_runtime_pack():
+                print("[arcade] live-world archive unavailable; continuing with mock data")
+
+            raw = await self.ctx.storage.get(_runtime._DO_WORLD_STATE_KEY)
+            world = _runtime.world_from_snapshot_json(raw)
+            if world is None or world.owner_id != user_id:
+                self._persisted_world_snapshot = None
+                world = await self.manager.get_world(user_id)
+            else:
+                self._persisted_world_snapshot = raw if isinstance(raw, str) else None
+                self.manager.worlds_by_user[user_id] = world
+                print(f"[arcade] restored hibernated world {world.world_id}")
+            return world
+
+    async def _persist_world(self, world, *, force: bool = False, before=None) -> str:
+        # Serialize once after message processing and compare against the exact
+        # snapshot already stored in SQLite. The base implementation serializes
+        # both before and after every message; this removes the pre-message copy
+        # and avoids redundant writes when a message does not mutate the world.
+        snapshot = _runtime.world_snapshot_json(world)
+        if force or snapshot != self._persisted_world_snapshot:
+            await self.ctx.storage.put(_runtime._DO_WORLD_STATE_KEY, snapshot)
+            self._persisted_world_snapshot = snapshot
+        return snapshot
 
     def _refresh_world_clients(self, world) -> None:
         main_clients = set()
@@ -53,6 +94,62 @@ class NoriArcadeSession(_runtime.NoriArcadeSession):
                 media_clients.add(adapter)
         world.clients = main_clients
         world.media_clients = media_clients
+
+    async def _handle_main_message(self, websocket, attachment: dict, raw: str) -> None:
+        user_id = attachment.get("userId")
+        if not isinstance(user_id, str) or not user_id:
+            websocket.close(1008, "session_invalid")
+            return
+
+        world = await self._load_world(user_id)
+        self._refresh_world_clients(world)
+        socket_id = attachment.get("socketId")
+        if not isinstance(socket_id, str) or not socket_id:
+            websocket.close(1008, "session_invalid")
+            return
+        adapter = _runtime._HibernatingSocketAdapter(websocket, socket_id)
+
+        await _runtime._prefetch_for_arcade_message(self.env, raw)
+        try:
+            message = json.loads(raw)
+        except json.JSONDecodeError:
+            await world.send_direct(
+                adapter,
+                _runtime.error_message("bad_request", "Invalid JSON"),
+            )
+            return
+        if not isinstance(message, dict):
+            await world.send_direct(
+                adapter,
+                _runtime.error_message("bad_request", "message must be an object"),
+            )
+            return
+
+        attachment = await self._capture_ai_settings(websocket, attachment, message)
+
+        if message.get("type") == "reset_my_web_world":
+            locale = message.get("locale") if isinstance(message.get("locale"), str) else None
+            world = await self.manager.reset_world(user_id, locale)
+            self._persisted_world_snapshot = None
+            self._refresh_world_clients(world)
+            await self._persist_world(world, force=True)
+            await world.send_direct(
+                adapter,
+                {"type": "web_world_reset_ack", "worldId": world.world_id},
+            )
+            await world.send_direct(
+                adapter,
+                {
+                    "type": "world_created",
+                    "world": world.world_payload(),
+                    "session": {"isAdmin": True},
+                },
+            )
+            return
+
+        await world.handle_client_message(adapter, message)
+        await _runtime._drain_world_tasks(world)
+        await self._persist_world(world)
 
 
 __all__ = ["Default", "NoriArcadeSession"]

--- a/server.py
+++ b/server.py
@@ -5,25 +5,48 @@ Run with `python server.py` and open http://127.0.0.1:4173.
 
 from __future__ import annotations
 
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
-from fastapi.middleware.gzip import GZipMiddleware
-
-from backend.api import api_router, register_mimetypes, static_router
-from backend.core.config import DEBUG, HOST, PORT
-from backend.services.ai_event_bridge import install_ai_event_bridge
-
-register_mimetypes()
-install_ai_event_bridge()
+from typing import Any
 
 
-def create_app(*, include_static: bool = True) -> FastAPI:
-    """Create and configure the FastAPI application.
+class _LazyASGIApp:
+    """Build the FastAPI application only when it actually receives traffic.
 
-    Local mode serves the frontend through FastAPI. Cloudflare Workers use
-    Workers Static Assets instead, so the Worker entrypoint disables the
-    filesystem-backed static router while keeping all HTTP/WebSocket APIs.
+    Cloudflare Durable Object invocations import ``worker.py`` and therefore
+    import this module, but Arcade WebSocket handling does not need the HTTP
+    router stack. Keeping the application lazy avoids initializing FastAPI,
+    routers, middleware, mimetypes, and the HTTP AI bridge on every cold DO
+    wake. Local Uvicorn usage remains compatible because this object is a
+    normal ASGI callable and proxies attribute access to the realized app.
     """
+
+    def __init__(self, *, include_static: bool) -> None:
+        self.include_static = include_static
+        self._app: Any | None = None
+
+    def _realize(self):
+        if self._app is None:
+            self._app = _build_app(include_static=self.include_static)
+        return self._app
+
+    async def __call__(self, scope, receive, send) -> None:
+        await self._realize()(scope, receive, send)
+
+    def __getattr__(self, name: str):
+        return getattr(self._realize(), name)
+
+
+def _build_app(*, include_static: bool):
+    """Import and construct the full HTTP stack on first use."""
+    from fastapi import FastAPI
+    from fastapi.middleware.cors import CORSMiddleware
+    from fastapi.middleware.gzip import GZipMiddleware
+
+    from backend.api import api_router, register_mimetypes, static_router
+    from backend.services.ai_event_bridge import install_ai_event_bridge
+
+    register_mimetypes()
+    install_ai_event_bridge()
+
     application = FastAPI(title="NoriOS Local Compatibility Server", version="2.0.0")
     application.add_middleware(GZipMiddleware, minimum_size=500)
     application.add_middleware(
@@ -39,11 +62,17 @@ def create_app(*, include_static: bool = True) -> FastAPI:
     return application
 
 
+def create_app(*, include_static: bool = True) -> _LazyASGIApp:
+    """Return a lazily initialized local/Cloudflare HTTP application."""
+    return _LazyASGIApp(include_static=include_static)
+
+
 app = create_app()
 
 if __name__ == "__main__":
     import uvicorn
 
+    from backend.core.config import DEBUG, HOST, PORT
     from backend.virtual_apps import live_pack
 
     print(f"NoriOS local compatibility server: http://{HOST}:{PORT}")

--- a/tests/test_do_runtime_efficiency.py
+++ b/tests/test_do_runtime_efficiency.py
@@ -5,6 +5,9 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
 ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
 
 

--- a/tests/test_do_runtime_efficiency.py
+++ b/tests/test_do_runtime_efficiency.py
@@ -24,6 +24,13 @@ def main() -> None:
     assert "fastapi" not in sys.modules
     assert "backend.api" not in sys.modules
 
+    # Arcade world state only needs a WebSocket-shaped object at runtime; the
+    # FastAPI WebSocket class is a typing aid and must not pull the HTTP stack
+    # into a hibernated Durable Object wake.
+    importlib.import_module("backend.session.world")
+    assert "fastapi" not in sys.modules
+    assert "backend.api" not in sys.modules
+
     # The production Durable Object subclass caches the exact SQLite snapshot
     # and serializes only after a message has finished mutating world state.
     assert "self._persisted_world_snapshot" in ENTRY

--- a/tests/test_do_runtime_efficiency.py
+++ b/tests/test_do_runtime_efficiency.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    # Importing the compatibility server is part of every Cloudflare Worker
+    # module load. It must stay cheap until an actual HTTP API request arrives.
+    sys.modules.pop("server", None)
+    server = importlib.import_module("server")
+    assert "fastapi" not in sys.modules
+    assert "backend.api" not in sys.modules
+
+    lazy_app = server.create_app(include_static=False)
+    assert callable(lazy_app)
+    assert "fastapi" not in sys.modules
+    assert "backend.api" not in sys.modules
+
+    # The production Durable Object subclass caches the exact SQLite snapshot
+    # and serializes only after a message has finished mutating world state.
+    assert "self._persisted_world_snapshot" in ENTRY
+    assert "snapshot != self._persisted_world_snapshot" in ENTRY
+    assert "await self._persist_world(world)" in ENTRY
+    assert "before = _runtime.world_snapshot_json" not in ENTRY
+
+    print("[ok] DO wake avoids eager FastAPI initialization and redundant snapshot copies")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Continues the Cloudflare Free-plan optimization after WebSocket Hibernation is stable.

### Lazy HTTP stack

`server.create_app()` now returns a lightweight ASGI wrapper and imports/builds FastAPI, routers, middleware, mimetypes, and the HTTP AI bridge only on the first real HTTP API request. Arcade Durable Object wakes still import `worker.py`, but no longer eagerly construct the unrelated FastAPI application.

Local Uvicorn remains compatible because the lazy wrapper is a normal ASGI callable and proxies attributes to the realized FastAPI app.

### Snapshot serialization/write reduction

The production `NoriArcadeSession` subclass now caches the exact JSON snapshot last read from/written to Durable Object SQLite storage. Main WebSocket messages no longer create a separate pre-message snapshot just for comparison. After message/follow-up processing, the world is serialized once and written only when the resulting JSON differs from the persisted cache.

This preserves reset behavior, hibernation restoration, R2 lazy loading, AI configuration handling, and the production `getWebSockets()` compatibility bridge.

### Validation

Adds a runtime-efficiency guard verifying:
- importing/creating the compatibility server does not eagerly import FastAPI or `backend.api`
- the production DO entrypoint caches persisted snapshots
- the optimized handler does not reintroduce a pre-message snapshot copy

Existing Hibernation, R2, AI, bundle-size, and Wrangler dry-run checks remain enabled.