### PR TITLE
perf: shorten Durable Object active windows

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Verify Durable Object runtime efficiency
         run: uv run python tests/test_do_runtime_efficiency.py
 
+      - name: Verify Durable Object active-window pacing
+        run: uv run python tests/test_do_active_window_pacing.py
+
       - name: Verify Workers Builds deploy wrapper
         run: uv run python tests/test_cloudflare_builds_deploy.py
 

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -9,11 +9,19 @@ Cloudflare's DurableObjectState WebSocket enumeration API is exposed as
 ``getWebSockets`` by the production runtime. Some Python-facing documentation
 and SDK surfaces have also used ``get_websockets``. Keep the compatibility
 bridge here so the hibernation runtime does not depend on one spelling.
+
+The local compatibility server intentionally keeps small presentation delays so
+its demo/game pacing feels natural. Durable Objects are billed by active wall
+clock time, so the Cloudflare entrypoint specializes those follow-up methods:
+text-mode chat settles immediately without generating fallback audio, while
+game follow-ups keep their ordering but omit artificial sleeps.
 """
 
 import json
 
 import worker_runtime as _runtime
+from backend.cartridges.chat import ChatCartridge as _ChatCartridge
+from backend.session.world import WorldSession as _WorldSession
 
 Default = _runtime.Default
 
@@ -32,6 +40,96 @@ def _runtime_websockets(ctx):
     raise AttributeError(
         "DurableObjectState exposes neither getWebSockets nor get_websockets"
     )
+
+
+async def _cloudflare_run_chat_reply(self, user_text: str) -> None:
+    """Generate a reply without billing presentation-only wall-clock delays."""
+    chat = self.cartridges.get("chat")
+    if not isinstance(chat, _ChatCartridge):
+        return
+
+    # The local runtime inserts 150 ms of theatrical latency before starting
+    # generation. It has no protocol meaning and only extends DO active time.
+    emotion, reply = await chat.generate_reply(user_text)
+    operation_id, message_id, commands = chat.build_agent_turn(reply, emotion)
+    for command in commands:
+        await self._dispatch_internal("chat", "agent", command)
+
+    # Production live-pack worlds default to text presentation. In text mode
+    # the reducer has already revealed/presented the block during ingestBlock,
+    # so generating synthetic PCM and waiting 1.1 + 0.45 + 0.1 seconds before
+    # settling cannot improve the UI; it only keeps the DO active.
+    if chat.state.get("presentationMode") == "text":
+        await self._dispatch_internal(
+            "chat",
+            "agent",
+            {
+                "type": "operationSettled",
+                "operationId": operation_id,
+                "outcome": "completed",
+            },
+        )
+        return
+
+    # Audio mode still keeps the existing fallback/audio-ack timeout behavior.
+    self._spawn(self._stream_chat_fallback(operation_id, message_id, reply))
+    self._spawn(self._ensure_chat_progress(operation_id))
+
+
+async def _cloudflare_settle_chat_after_audio(self, operation_id: str) -> None:
+    """Audio completion is already an acknowledgement; settle without 100 ms."""
+    await self._dispatch_internal(
+        "chat",
+        "agent",
+        {
+            "type": "operationSettled",
+            "operationId": operation_id,
+            "outcome": "completed",
+        },
+    )
+
+
+async def _cloudflare_run_agent_turns(self, cartridge_id: str) -> None:
+    """Preserve ordered agent turns without 350 ms of billed delay per turn."""
+    for _ in range(8):
+        # Yield cooperatively without scheduling a real timer. This preserves
+        # event-loop fairness while avoiding presentation-only wall time.
+        await _runtime.asyncio.sleep(0)
+        cartridge = self.cartridges.get(cartridge_id)
+        if cartridge is None:
+            return
+        command = getattr(cartridge, "agent_next_command", lambda: None)()
+        if not command:
+            return
+        commit = await self._dispatch_internal(cartridge_id, "agent", command)
+        if commit is None:
+            return
+
+
+async def _cloudflare_start_next_pictionary_round(self) -> None:
+    """Start the next valid round without a presentation-only 1.2 s wait."""
+    cartridge = self.cartridges.get("pictionary")
+    if cartridge is None:
+        return
+    game = cartridge.state.get("gameState")
+    if (
+        isinstance(game, dict)
+        and game.get("phase") == "PLAYING"
+        and game.get("round", {}).get("status") != "active"
+    ):
+        await self._dispatch_internal(
+            "pictionary",
+            "agent",
+            {"type": "startNextRound", "atMs": int(_runtime.time.time() * 1000)},
+        )
+
+
+# Apply pacing specialization only in the Cloudflare build entrypoint. Local
+# Uvicorn continues using backend.session.world's original human-facing delays.
+_WorldSession._run_chat_reply = _cloudflare_run_chat_reply
+_WorldSession._settle_chat_after_audio = _cloudflare_settle_chat_after_audio
+_WorldSession._run_agent_turns = _cloudflare_run_agent_turns
+_WorldSession._start_next_pictionary_round = _cloudflare_start_next_pictionary_round
 
 
 class NoriArcadeSession(_runtime.NoriArcadeSession):

--- a/tests/test_do_active_window_pacing.py
+++ b/tests/test_do_active_window_pacing.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
+WORLD = (ROOT / "backend" / "session" / "world.py").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    # Local mode intentionally keeps human-facing presentation delays.
+    assert "await asyncio.sleep(0.15)" in WORLD
+    assert "await asyncio.sleep(0.35)" in WORLD
+    assert "await asyncio.sleep(1.2)" in WORLD
+    assert "await asyncio.sleep(1.1)" in WORLD
+
+    # Cloudflare replaces only the presentation-only methods so Durable Object
+    # active wall-clock time is not spent sleeping for UI pacing.
+    assert "_WorldSession._run_chat_reply = _cloudflare_run_chat_reply" in ENTRY
+    assert "_WorldSession._run_agent_turns = _cloudflare_run_agent_turns" in ENTRY
+    assert "_WorldSession._start_next_pictionary_round = _cloudflare_start_next_pictionary_round" in ENTRY
+    assert "_WorldSession._settle_chat_after_audio = _cloudflare_settle_chat_after_audio" in ENTRY
+
+    # Production live-pack worlds use text presentation. Text replies must settle
+    # immediately and must not start synthetic PCM/audio-timeout tasks.
+    assert 'if chat.state.get("presentationMode") == "text":' in ENTRY
+    text_fast_path = ENTRY.split('if chat.state.get("presentationMode") == "text":', 1)[1]
+    text_fast_path, audio_path = text_fast_path.split("# Audio mode still keeps", 1)
+    assert '"type": "operationSettled"' in text_fast_path
+    assert "_stream_chat_fallback" not in text_fast_path
+    assert "_ensure_chat_progress" not in text_fast_path
+    assert "self._spawn(self._stream_chat_fallback" in audio_path
+    assert "self._spawn(self._ensure_chat_progress" in audio_path
+
+    # Cloudflare-specific game follow-ups may cooperatively yield, but they must
+    # not reintroduce real presentation timers that extend DO duration.
+    assert "await _runtime.asyncio.sleep(0)" in ENTRY
+    for delay in ("sleep(0.15)", "sleep(0.1)", "sleep(0.35)", "sleep(1.2)"):
+        assert delay not in ENTRY
+
+    print("[ok] Cloudflare DO follow-ups preserve ordering without billed presentation waits")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Further reduces Durable Object billable wall-clock time after WebSocket Hibernation and wake/snapshot optimizations are stable.

### Cloudflare-only pacing specialization

Local Uvicorn keeps the original human-facing presentation delays. The Cloudflare entrypoint specializes only the follow-up methods that otherwise keep a Durable Object active while sleeping:

- removes the 150 ms pre-generation chat delay
- text-mode chat settles immediately after its reducer transitions and does not generate synthetic fallback PCM or wait through the 1.1 + 0.45 + 0.1 second audio fallback timers
- audio-mode chat keeps the existing fallback/audio acknowledgement behavior
- removes the 100 ms post-`audioDone` settle delay
- removes the 350 ms artificial delay before each game-agent turn while preserving ordered sequential transitions
- removes the 1.2 second artificial delay before starting the next valid Pictionary round
- uses only `asyncio.sleep(0)` where a cooperative event-loop yield is useful

Production live-pack worlds default to text presentation, so the largest chat pacing cost disappears from the common Cloudflare path without changing the audio-mode fallback contract.

### Validation

Adds `tests/test_do_active_window_pacing.py` and CI coverage ensuring:
- local-mode presentation sleeps remain intact
- Cloudflare overrides the intended follow-up methods only
- text-mode chat never starts fallback audio/timeout tasks
- audio mode still retains those fallbacks
- no real presentation timers are reintroduced in the Cloudflare specialization

Existing Hibernation, snapshot, R2, AI, import-efficiency, bundle-size, and Wrangler dry-run checks remain enabled.