### PR TITLE
perf: cache fingerprinted static assets

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Verify Durable Object active-window pacing
         run: uv run python tests/test_do_active_window_pacing.py
 
+      - name: Verify static asset cache policy
+        run: uv run python tests/test_static_asset_cache.py
+
       - name: Verify Workers Builds deploy wrapper
         run: uv run python tests/test_cloudflare_builds_deploy.py
 

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,11 @@
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/index.html
+  Cache-Control: public, max-age=0, must-revalidate
+
+/nori-ai-settings.js
+  Cache-Control: public, max-age=0, must-revalidate
+
+/nori-runtime-shims.js
+  Cache-Control: public, max-age=0, must-revalidate

--- a/tests/test_static_asset_cache.py
+++ b/tests/test_static_asset_cache.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+HEADERS = (ROOT / "public" / "_headers").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    assert "/assets/*" in HEADERS
+    assert "Cache-Control: public, max-age=31536000, immutable" in HEADERS
+
+    # Mutable bootstrap files keep revalidation semantics so a new deployment
+    # cannot strand browsers on an old runtime shim or AI settings bridge.
+    for path in ("/index.html", "/nori-ai-settings.js", "/nori-runtime-shims.js"):
+        assert path in HEADERS
+    assert HEADERS.count("Cache-Control: public, max-age=0, must-revalidate") >= 3
+
+    # Stable-name Live2D/model resources are intentionally not marked immutable;
+    # they may be replaced without a filename hash changing.
+    assert "/ARGNori_web/*" not in HEADERS
+
+    print("[ok] fingerprinted assets use immutable browser caching while mutable entry files revalidate")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Improves repeat-load performance for NoriOS on Cloudflare Workers Static Assets.

### Cache policy

Adds `public/_headers` so Vite fingerprinted assets under `/assets/*` are served with:

`Cache-Control: public, max-age=31536000, immutable`

Mutable bootstrap files keep revalidation semantics:
- `/index.html`
- `/nori-ai-settings.js`
- `/nori-runtime-shims.js`

Stable-name Live2D/model files under `/ARGNori_web/*` are intentionally not marked immutable so they can still be replaced without a filename hash change.

### Validation

Adds `tests/test_static_asset_cache.py` and CI coverage to prevent accidentally applying immutable caching to mutable runtime entry files.

This change does not modify Durable Object, WebSocket, R2 world-state, or API behavior.