### PR TITLE
feat: allow local guest access with any text

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Verify static asset cache policy
         run: uv run python tests/test_static_asset_cache.py
 
+      - name: Verify local access gate
+        run: uv run python tests/test_local_access_gate.py
+
       - name: Verify Workers Builds deploy wrapper
         run: uv run python tests/test_cloudflare_builds_deploy.py
 

--- a/public/nori-runtime-shims.js
+++ b/public/nori-runtime-shims.js
@@ -1,26 +1,51 @@
 (() => {
   "use strict";
 
+  const ACCESS_FLAG = "nori.local.access.v1";
+
+  const pathnameOf = (value) => {
+    try {
+      const raw = value instanceof Request ? value.url : String(value || "");
+      return new URL(raw, window.location.href).pathname;
+    } catch {
+      return "";
+    }
+  };
+
   // The shipped NoriOS bundle reports optional performance vitals to the
   // original os.inori.ai debug endpoint. Privacy/ad-blocking extensions often
   // classify that endpoint as telemetry and block it, which creates noisy
   // ERR_BLOCKED_BY_CLIENT console errors even though the application itself is
   // healthy. Keep that optional diagnostic local instead of touching the
   // network. No application API, Arcade request, or asset request is matched.
-  const isPerfVitalsUrl = (value) => {
-    try {
-      const raw = value instanceof Request ? value.url : String(value || "");
-      const url = new URL(raw, window.location.href);
-      return url.pathname === "/api/debug/perf-vitals";
-    } catch {
-      return false;
-    }
-  };
+  const isPerfVitalsUrl = (value) => pathnameOf(value) === "/api/debug/perf-vitals";
+  const isSessionUrl = (value) => pathnameOf(value) === "/api/auth/get-session";
+
+  const guestSessionResponse = () =>
+    new Response(
+      JSON.stringify({
+        session: {
+          id: "session-local-access",
+          userId: "guest-user-001",
+          expiresAt: Date.now() + 30 * 24 * 60 * 60 * 1000,
+        },
+        user: {
+          id: "guest-user-001",
+          name: "Operator",
+          email: "operator@nori.local",
+          image: "/icon.png",
+        },
+      }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
 
   const nativeFetch = window.fetch.bind(window);
   window.fetch = function noriFetch(input, init) {
     if (isPerfVitalsUrl(input)) {
       return Promise.resolve(new Response(null, { status: 204 }));
+    }
+    if (sessionStorage.getItem(ACCESS_FLAG) === "1" && isSessionUrl(input)) {
+      return Promise.resolve(guestSessionResponse());
     }
     return nativeFetch(input, init);
   };
@@ -32,4 +57,73 @@
       return nativeSendBeacon(url, data);
     };
   }
+
+  // The shipped AlephPro gate uses an email + OTP form. For this local guest
+  // deployment the gate is intentionally decorative: any non-empty text should
+  // open the existing guest session. Patch only the first access-gate form;
+  // the OTP form has no `input.field`, so it is left alone.
+  const patchAccessGate = () => {
+    const gate = document.getElementById("access-gate");
+    if (!gate) return;
+
+    const input = gate.querySelector("form input.field");
+    if (input instanceof HTMLInputElement) {
+      if (input.type !== "text") input.type = "text";
+      if (input.autocomplete !== "off") input.autocomplete = "off";
+      if (input.placeholder !== "输入任意字符即可接入") {
+        input.placeholder = "输入任意字符即可接入";
+      }
+      input.dataset.noriAccessBypass = "1";
+    }
+
+    const submit = gate.querySelector('form button[type="submit"].prime');
+    if (submit instanceof HTMLButtonElement && !submit.disabled && submit.dataset.noriAccessBusy !== "1") {
+      if (submit.textContent !== "直接接入") submit.textContent = "直接接入";
+    }
+  };
+
+  const startAccessGateObserver = () => {
+    patchAccessGate();
+    const observer = new MutationObserver(patchAccessGate);
+    observer.observe(document.documentElement, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ["type", "placeholder", "disabled"],
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", startAccessGateObserver, { once: true });
+  } else {
+    startAccessGateObserver();
+  }
+
+  document.addEventListener(
+    "submit",
+    (event) => {
+      const form = event.target;
+      if (!(form instanceof HTMLFormElement) || !form.closest("#access-gate")) return;
+
+      const input = form.querySelector("input.field");
+      if (!(input instanceof HTMLInputElement)) return;
+      const value = input.value.trim();
+      if (!value) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      event.stopImmediatePropagation();
+
+      const submit = form.querySelector('button[type="submit"]');
+      if (submit instanceof HTMLButtonElement) {
+        submit.dataset.noriAccessBusy = "1";
+        submit.disabled = true;
+        submit.textContent = "正在接入…";
+      }
+
+      sessionStorage.setItem(ACCESS_FLAG, "1");
+      window.location.reload();
+    },
+    true,
+  );
 })();

--- a/tests/test_browser_runtime_shims.py
+++ b/tests/test_browser_runtime_shims.py
@@ -14,16 +14,17 @@ def main() -> None:
     assert app_script in INDEX
     assert INDEX.index(shim_script) < INDEX.index(app_script)
 
-    assert 'url.pathname === "/api/debug/perf-vitals"' in SHIM
+    assert 'pathnameOf(value) === "/api/debug/perf-vitals"' in SHIM
     assert "window.fetch = function noriFetch" in SHIM
     assert "navigator.sendBeacon = function noriSendBeacon" in SHIM
 
-    # This shim must stay scoped to optional telemetry. Arcade transport and
-    # application APIs must remain untouched.
+    # Runtime compatibility additions may handle the local guest access gate,
+    # but they must never patch Arcade/WebSocket transport or intercept general
+    # application API traffic.
     assert "WebSocket.prototype" not in SHIM
     assert "/api/arcade" not in SHIM
 
-    print("[ok] browser runtime shim suppresses only optional perf-vitals telemetry")
+    print("[ok] browser runtime shim preserves telemetry and transport boundaries")
 
 
 if __name__ == "__main__":

--- a/tests/test_local_access_gate.py
+++ b/tests/test_local_access_gate.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SHIM = (ROOT / "public" / "nori-runtime-shims.js").read_text(encoding="utf-8")
+AUTH = (ROOT / "backend" / "api" / "auth.py").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    # The browser-side access gate is backed by the server's existing guest
+    # semantics; keep the default guest path available on Cloudflare.
+    assert 'os.getenv("NORI_AUTO_GUEST", "true")' in AUTH
+    assert '"guest-user-001"' in AUTH
+
+    # The shipped LoginPage uses an email field and native email validation.
+    # The compatibility shim must turn only the access-gate field into text so
+    # arbitrary non-empty input can reach the capture-phase submit handler.
+    assert 'const ACCESS_FLAG = "nori.local.access.v1"' in SHIM
+    assert 'input.type !== "text"' in SHIM
+    assert 'input.placeholder = "输入任意字符即可接入"' in SHIM
+    assert 'form.closest("#access-gate")' in SHIM
+    assert 'const value = input.value.trim()' in SHIM
+    assert 'if (!value) return' in SHIM
+
+    # After the one-time gate action, only /api/auth/get-session is substituted
+    # with the existing guest identity. No email/OTP request is fabricated.
+    assert 'pathnameOf(value) === "/api/auth/get-session"' in SHIM
+    assert 'sessionStorage.setItem(ACCESS_FLAG, "1")' in SHIM
+    assert 'window.location.reload()' in SHIM
+    assert 'guest-user-001' in SHIM
+    assert '/api/auth/sign-in/email-otp' not in SHIM
+    assert '/api/auth/email-otp/send-verification-otp' not in SHIM
+
+    print("[ok] AlephPro access gate accepts any non-empty text as local guest access")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes the decorative AlephPro access gate match the local/experimental NoriOS deployment: entering any non-empty text and submitting immediately opens the existing guest/operator session.

### Behavior

- changes only the access-gate email field at runtime to a normal text field
- placeholder becomes `输入任意字符即可接入`
- submit button becomes `直接接入`
- any non-empty value stores a session-scoped local access flag and reloads
- after reload, only `/api/auth/get-session` is locally represented as the existing `guest-user-001` identity
- blank input does not pass
- the typed value is not sent, stored as an email, or used as an account identifier
- no OTP/sign-in endpoint is fabricated or called by the bypass
- closing the browser session clears the `sessionStorage` flag naturally

The server's existing `NORI_AUTO_GUEST=true` default continues to back guest API/Arcade access, so this is intentionally a presentation gate rather than a security boundary.

### Validation

Adds `tests/test_local_access_gate.py` plus CI coverage and retains JavaScript syntax, Hibernation, R2, AI, cache-policy, bundle-size, and Wrangler dry-run checks.