### PR TITLE
perf: reduce Python memory and CPU overhead

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -48,6 +48,9 @@ jobs:
       - name: Verify Durable Object active-window pacing
         run: uv run python tests/test_do_active_window_pacing.py
 
+      - name: Verify Python memory and CPU hot paths
+        run: uv run python tests/test_python_memory_cpu.py
+
       - name: Verify static asset cache policy
         run: uv run python tests/test_static_asset_cache.py
 

--- a/backend/session/persistence.py
+++ b/backend/session/persistence.py
@@ -28,12 +28,20 @@ def _non_negative_int(value: Any, default: int = 0) -> int:
     return max(0, parsed)
 
 
-def world_to_snapshot(world: WorldSession) -> Dict[str, Json]:
-    """Return the durable, JSON-safe portion of one world session."""
+def _world_snapshot_view(world: WorldSession) -> Dict[str, Json]:
+    """Build a read-only serialization view without cloning cartridge state.
+
+    ``json.dumps`` never mutates its input, so the hot persistence path can
+    reference each cartridge's current state directly. This avoids holding a
+    second complete world object graph while a Durable Object is being
+    serialized. Callers that need an independently mutable Python snapshot
+    should use :func:`world_to_snapshot`, which preserves the old deep-copy
+    contract.
+    """
     cartridges: Dict[str, Json] = {}
     for cartridge_id, cartridge in world.cartridges.items():
         cartridges[cartridge_id] = {
-            "state": deepcopy(cartridge.state),
+            "state": cartridge.state,
             "headVersion": int(cartridge.head_version),
             "visibleVersion": int(cartridge.visible_version),
         }
@@ -43,15 +51,23 @@ def world_to_snapshot(world: WorldSession) -> Dict[str, Json]:
         "ownerId": world.owner_id,
         "worldId": world.world_id,
         "locale": world.locale,
-        "mediaGrants": sorted(grant for grant in world.media_grants if isinstance(grant, str)),
+        "mediaGrants": sorted(
+            grant for grant in world.media_grants if isinstance(grant, str)
+        ),
         "mediaSequence": int(world._media_sequence),
         "cartridges": cartridges,
     }
 
 
+def world_to_snapshot(world: WorldSession) -> Dict[str, Json]:
+    """Return an independently mutable JSON-safe snapshot of one world."""
+    return deepcopy(_world_snapshot_view(world))
+
+
 def world_snapshot_json(world: WorldSession) -> str:
+    """Serialize one world without first duplicating the full state graph."""
     return json.dumps(
-        world_to_snapshot(world),
+        _world_snapshot_view(world),
         ensure_ascii=False,
         separators=(",", ":"),
         sort_keys=True,
@@ -59,7 +75,7 @@ def world_snapshot_json(world: WorldSession) -> str:
 
 
 def world_from_snapshot(payload: Any) -> WorldSession | None:
-    """Restore a world from a validated snapshot, or return ``None`` if corrupt."""
+    """Restore a world from a validated snapshot, or ``None`` if corrupt."""
     if not isinstance(payload, dict) or payload.get("version") != SNAPSHOT_VERSION:
         return None
 
@@ -87,6 +103,9 @@ def world_from_snapshot(payload: Any) -> WorldSession | None:
         cartridge = CARTRIDGE_REGISTRY.create(cartridge_id)
         if cartridge is None:
             continue
+        # Restore is comparatively cold (only on wake/recovery), so keep the
+        # defensive copy here. The CPU/memory win is in the per-message write
+        # path above, not in weakening the public restore isolation contract.
         cartridge.state = deepcopy(state)
         cartridge.head_version = _non_negative_int(saved.get("headVersion"))
         cartridge.visible_version = min(

--- a/backend/virtual_apps/live_pack.py
+++ b/backend/virtual_apps/live_pack.py
@@ -186,12 +186,23 @@ def summary() -> str:
     )
 
 
-def _list(key: str) -> List[Dict[str, Any]]:
+def _section_view(key: str) -> List[Dict[str, Any]]:
+    """Return the resident section by reference for trusted read-only paths.
+
+    The R2-decoded object graph is already private to this isolate. Internal
+    Cloudflare hot paths can safely iterate it without materializing a second
+    deep copy. Public accessors below keep their defensive-copy semantics.
+    """
     p = _pack()
     if not p:
         return []
     val = p.get(key)
-    return copy.deepcopy(val) if isinstance(val, list) else []
+    return val if isinstance(val, list) else []
+
+
+def _list(key: str) -> List[Dict[str, Any]]:
+    # Preserve the historical public isolation contract for local callers.
+    return copy.deepcopy(_section_view(key))
 
 
 def mail_artifacts() -> List[Dict[str, Any]]:
@@ -245,7 +256,9 @@ def page(lookup_key: str) -> Optional[Dict[str, Any]]:
         return None
     if _PAGE_INDEX is None:
         idx: Dict[str, Dict[str, Any]] = {}
-        for entry in _list("browser_pages"):
+        # Index the resident shard directly. Previously `_list()` deep-copied
+        # every page first, keeping a second full page graph alive beside R2.
+        for entry in _section_view("browser_pages"):
             aliases = {
                 entry.get("key"),
                 (entry.get("data") or {}).get("url"),
@@ -269,11 +282,18 @@ def page(lookup_key: str) -> Optional[Dict[str, Any]]:
         }
         if len({id(value) for value in candidates.values()}) == 1:
             entry = next(iter(candidates.values()))
+    # Only the one page crossing the application boundary is copied.
     return copy.deepcopy(entry) if entry else None
 
 
 def all_pages_raw() -> List[Dict[str, Any]]:
-    return _list("browser_pages")
+    """Return a shallow list view for read-only archive scans.
+
+    The list container is detached so callers cannot append/remove cache
+    entries, while page dictionaries stay shared to avoid duplicating an
+    entire browser shard for one bounty lookup.
+    """
+    return list(_section_view("browser_pages"))
 
 
 def facts() -> Dict[str, Any]:

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -42,6 +42,73 @@ def _runtime_websockets(ctx):
     )
 
 
+def _cloudflare_archive_list(section: str):
+    """Shallow-copy a resident R2 section without duplicating artifact trees."""
+    return list(_runtime.live_pack._section_view(section))
+
+
+# The local compatibility API intentionally returns defensive deep copies.
+# Inside a Cloudflare isolate these consumers are trusted read-only paths; a
+# detached list shell is enough for Mail's runtime append behavior while the
+# large archived dict/string graph remains single-copy in memory.
+_runtime.live_pack.mail_artifacts = lambda: _cloudflare_archive_list("mail_artifacts")
+_runtime.live_pack.file_artifacts = lambda: _cloudflare_archive_list("file_artifacts")
+_runtime.live_pack.signal_thread_artifacts = lambda: _cloudflare_archive_list(
+    "signal_thread_artifacts"
+)
+_runtime.live_pack.signal_message_artifacts = lambda: _cloudflare_archive_list(
+    "signal_message_artifacts"
+)
+
+
+async def _prefetch_parsed_arcade_message(env, message: dict) -> None:
+    """Populate lazy R2 sections from an already-decoded Arcade message."""
+    if message.get("type") != "event":
+        return
+
+    channel = message.get("channel")
+    payload = message.get("payload")
+    payload = payload if isinstance(payload, dict) else {}
+
+    if channel == "manifold.artifacts.request":
+        req_type = payload.get("artifactType")
+        mapping = {
+            "mail": ("mail_artifacts",),
+            "file": ("file_artifacts",),
+            "signal_thread": ("signal_thread_artifacts",),
+            "signal_message": ("signal_message_artifacts",),
+            None: (
+                "mail_artifacts",
+                "file_artifacts",
+                "signal_thread_artifacts",
+                "signal_message_artifacts",
+            ),
+        }
+        for section in mapping.get(req_type, ()):
+            await _runtime._ensure_live_section(env, section)
+        return
+
+    if channel == "manifold.artifacts.fetch":
+        if payload.get("artifactType") == "browser_page":
+            lookup_key = payload.get("lookup_key")
+            if isinstance(lookup_key, str) and lookup_key:
+                await _runtime._ensure_browser_lookup(env, lookup_key)
+        return
+
+    if channel == "manifold.bounty.submit":
+        if payload.get("fileId"):
+            await _runtime._ensure_live_section(env, "file_artifacts")
+        url = payload.get("url")
+        if isinstance(url, str) and url:
+            await _runtime._ensure_browser_lookup(env, url, allow_contains=True)
+
+
+def _prune_transition_history(world) -> None:
+    """Drop transition bodies once their wire messages and snapshot are built."""
+    for cartridge in world.cartridges.values():
+        cartridge.transitions.clear()
+
+
 async def _cloudflare_run_chat_reply(self, user_text: str) -> None:
     """Generate a reply without billing presentation-only wall-clock delays."""
     chat = self.cartridges.get("chat")
@@ -165,10 +232,16 @@ class NoriArcadeSession(_runtime.NoriArcadeSession):
 
     async def _persist_world(self, world, *, force: bool = False, before=None) -> str:
         # Serialize once after message processing and compare against the exact
-        # snapshot already stored in SQLite. The base implementation serializes
-        # both before and after every message; this removes the pre-message copy
-        # and avoids redundant writes when a message does not mutate the world.
+        # snapshot already stored in SQLite. The JSON serializer references the
+        # live cartridge states directly, avoiding a second full world graph.
         snapshot = _runtime.world_snapshot_json(world)
+
+        # Transition bodies have already been emitted over the wire and are not
+        # part of durable snapshots. Release them before awaiting SQLite I/O so
+        # a long-lived isolate does not accumulate one deep-copied transition
+        # per commit.
+        _prune_transition_history(world)
+
         if force or snapshot != self._persisted_world_snapshot:
             await self.ctx.storage.put(_runtime._DO_WORLD_STATE_KEY, snapshot)
             self._persisted_world_snapshot = snapshot
@@ -207,7 +280,8 @@ class NoriArcadeSession(_runtime.NoriArcadeSession):
             return
         adapter = _runtime._HibernatingSocketAdapter(websocket, socket_id)
 
-        await _runtime._prefetch_for_arcade_message(self.env, raw)
+        # Decode once. The old path parsed here and then parsed the same raw
+        # payload again inside `_prefetch_for_arcade_message`.
         try:
             message = json.loads(raw)
         except json.JSONDecodeError:
@@ -223,6 +297,7 @@ class NoriArcadeSession(_runtime.NoriArcadeSession):
             )
             return
 
+        await _prefetch_parsed_arcade_message(self.env, message)
         attachment = await self._capture_ai_settings(websocket, attachment, message)
 
         if message.get("type") == "reset_my_web_world":

--- a/tests/test_python_memory_cpu.py
+++ b/tests/test_python_memory_cpu.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from backend.session import persistence
+from backend.session.world import WorldSession
+from backend.virtual_apps import live_pack
+
+ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
+
+
+def _test_snapshot_hot_path() -> None:
+    world = WorldSession("memory-test", "zh-CN")
+    chat = world.cartridges["chat"]
+    chat.state["__memoryProbe"] = {"nested": [1, 2, 3]}
+
+    original_deepcopy = persistence.deepcopy
+    calls = 0
+
+    def counting_deepcopy(value):
+        nonlocal calls
+        calls += 1
+        return original_deepcopy(value)
+
+    persistence.deepcopy = counting_deepcopy
+    try:
+        raw = persistence.world_snapshot_json(world)
+        assert calls == 0, "hot JSON persistence must not deepcopy the world graph"
+        payload = json.loads(raw)
+        assert payload["cartridges"]["chat"]["state"]["__memoryProbe"]["nested"] == [
+            1,
+            2,
+            3,
+        ]
+
+        detached = persistence.world_to_snapshot(world)
+        assert calls == 1, "public Python snapshot must keep defensive-copy semantics"
+        detached["cartridges"]["chat"]["state"]["__memoryProbe"]["nested"].append(4)
+        assert chat.state["__memoryProbe"]["nested"] == [1, 2, 3]
+    finally:
+        persistence.deepcopy = original_deepcopy
+
+
+def _test_live_pack_single_resident_graph() -> None:
+    sample = {
+        "world_id": "memory-world",
+        "mail_artifacts": [
+            {"id": "mail-1", "data": {"subject": "hello", "labels": ["a"]}}
+        ],
+        "browser_pages": [
+            {
+                "key": "https://example.test/",
+                "aliases": ["http://example.test/"],
+                "data": {"url": "https://example.test/", "title": "Example"},
+            }
+        ],
+    }
+
+    live_pack.set_disabled(False)
+    assert live_pack.install_pack(sample)
+
+    # Trusted internal readers see the one resident R2-decoded graph directly.
+    view = live_pack._section_view("browser_pages")
+    assert view is sample["browser_pages"]
+    assert view[0] is sample["browser_pages"][0]
+
+    # Public artifact accessors retain their historical deep-copy isolation.
+    copied_mail = live_pack.mail_artifacts()
+    copied_mail[0]["data"]["labels"].append("mutated")
+    assert sample["mail_artifacts"][0]["data"]["labels"] == ["a"]
+
+    # Raw browser scans only detach the list shell; the heavy page tree is not
+    # duplicated. A concrete page crossing the app boundary is still copied.
+    raw_pages = live_pack.all_pages_raw()
+    assert raw_pages is not sample["browser_pages"]
+    assert raw_pages[0] is sample["browser_pages"][0]
+
+    page = live_pack.page("https://example.test/")
+    assert page is not None
+    page["data"]["title"] = "Changed"
+    assert live_pack.page("https://example.test/")["data"]["title"] == "Example"
+
+    live_pack.set_disabled(True)
+
+
+def _test_cloudflare_hot_path_source() -> None:
+    # One incoming frame is decoded exactly once in the production override.
+    assert ENTRY.count("message = json.loads(raw)") == 1
+    assert "_prefetch_parsed_arcade_message(self.env, message)" in ENTRY
+    assert "_prefetch_for_arcade_message(self.env, raw)" not in ENTRY
+
+    # Production artifact accessors only copy list pointers, not the archived
+    # object graph, and transition bodies are released after serialization.
+    assert "_cloudflare_archive_list" in ENTRY
+    assert 'mail_artifacts = lambda: _cloudflare_archive_list("mail_artifacts")' in ENTRY
+    assert "_prune_transition_history(world)" in ENTRY
+    assert "cartridge.transitions.clear()" in ENTRY
+
+
+def main() -> None:
+    _test_snapshot_hot_path()
+    _test_live_pack_single_resident_graph()
+    _test_cloudflare_hot_path_source()
+    print(
+        "[ok] Cloudflare persistence, archive reads, JSON parsing, and transition history avoid redundant object graphs"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Reduces Python/Pyodide peak memory and CPU overhead in the Cloudflare Durable Object hot path without weakening the local compatibility APIs.

### Durable snapshot serialization
- `world_snapshot_json()` now serializes a read-only view of live cartridge state instead of deep-copying the entire world first.
- `world_to_snapshot()` keeps the existing defensive deep-copy contract for callers that need an independently mutable Python object.
- restore remains defensive and deep-copies stored state because wake/recovery is a cold path.

### Live archive memory
- adds an internal resident-section view so trusted Cloudflare read paths can iterate the one R2-decoded object graph.
- Browser URL indexes now point directly into the resident browser shard instead of indexing a deep-copied second shard.
- `all_pages_raw()` detaches only the list shell for read-only scans.
- production Mail/File/Signal accessors shallow-copy only the outer list while reusing immutable archived artifact trees; local public accessors retain defensive deep-copy behavior.

### WebSocket CPU / long-session memory
- production Arcade frames are decoded once and the parsed message is reused for lazy R2 prefetch and dispatch.
- historical cartridge transition bodies are cleared after the durable JSON snapshot is created and before SQLite I/O; they have already been broadcast and are intentionally excluded from persistence.

### Validation
Adds `tests/test_python_memory_cpu.py` to verify:
- hot JSON persistence performs zero `deepcopy` calls
- public Python snapshots remain isolated
- resident browser shards are single-copy while returned pages stay isolated
- production source keeps parse-once, shallow archive lists, and transition pruning

Existing Hibernation, R2, AI, cache, local access gate, bundle-size, compile, and Wrangler dry-run checks remain enabled.