### PR TITLE
fix: serve Convex compatibility API without ASGI

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Verify HTTP API runtime
         run: uv run python tests/test_http_api_runtime.py
 
+      - name: Verify edge Convex API
+        run: uv run python tests/test_edge_convex_api.py
+
       - name: Verify runtime live pack injection
         run: uv run python tests/test_live_pack_runtime.py
 

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -23,7 +23,67 @@ import worker_runtime as _runtime
 from backend.cartridges.chat import ChatCartridge as _ChatCartridge
 from backend.session.world import WorldSession as _WorldSession
 
-Default = _runtime.Default
+
+_EDGE_CONVEX_PATHS = {
+    "/api/query",
+    "/api/mutation",
+    "/api/action",
+    "/api/function",
+    "/api/query_at_ts",
+}
+
+
+async def _serve_edge_convex_api(path: str, request):
+    """Serve the tiny Convex compatibility surface without FastAPI/ASGI."""
+    method = request.method.upper()
+    if path == "/api/query_ts" and method == "POST":
+        return _runtime._json_response({"ts": "0"})
+    if path not in _EDGE_CONVEX_PATHS or method != "POST":
+        return None
+
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    function_path = body.get("path") if isinstance(body, dict) else None
+
+    if function_path == "auth/wsTickets:issueWebUserWsTicket":
+        ticket = await _runtime._EDGE_TICKET_MANAGER.issue_ticket(
+            _runtime._EDGE_GUEST_USER_ID
+        )
+        return _runtime._json_response(
+            {"status": "success", "value": {"ticket": ticket}, "logLines": []}
+        )
+
+    if function_path == "auth/otpEmail:preflightOtpSend":
+        return _runtime._json_response(
+            {"status": "success", "value": None, "logLines": []}
+        )
+
+    return _runtime._json_response(
+        {
+            "status": "error",
+            "errorMessage": (
+                "Unsupported local Convex function: "
+                f"{function_path or '<missing>'}"
+            ),
+            "logLines": [],
+        }
+    )
+
+
+class Default(_runtime.Default):
+    """Keep bootstrap and Convex compatibility requests off the ASGI cold path."""
+
+    async def fetch(self, request):
+        path = _runtime.urlsplit(request.url).path
+        if path == "/api/query_ts" or path in _EDGE_CONVEX_PATHS:
+            # Ticket signatures must use the runtime-bound SECRET_KEY.
+            _runtime._apply_runtime_bindings(self.env)
+            response = await _serve_edge_convex_api(path, request)
+            if response is not None:
+                return response
+        return await super().fetch(request)
 
 
 def _runtime_websockets(ctx):

--- a/tests/test_edge_convex_api.py
+++ b/tests/test_edge_convex_api.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
+
+
+def main() -> None:
+    for path in (
+        "/api/query",
+        "/api/mutation",
+        "/api/action",
+        "/api/function",
+        "/api/query_at_ts",
+        "/api/query_ts",
+    ):
+        assert path in ENTRY
+
+    assert "class Default(_runtime.Default)" in ENTRY
+    assert "await request.json()" in ENTRY
+    assert "auth/wsTickets:issueWebUserWsTicket" in ENTRY
+    assert "auth/otpEmail:preflightOtpSend" in ENTRY
+    assert "await _serve_edge_convex_api(path, request)" in ENTRY
+
+    edge_call = ENTRY.index("await _serve_edge_convex_api(path, request)")
+    fallback = ENTRY.index("return await super().fetch(request)")
+    assert edge_call < fallback
+
+    print("[ok] Cloudflare Convex compatibility routes bypass the ASGI cold path")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_http_api_runtime.py
+++ b/tests/test_http_api_runtime.py
@@ -30,7 +30,38 @@ async def main() -> None:
         token = ticket.json().get("ticket")
         assert isinstance(token, str) and "." in token
 
-    print("[ok] concrete FastAPI app serves entry-status and Arcade ticket endpoints")
+        # The shipped client also uses Convex-compatible HTTP RPCs. Keep their
+        # response contract stable even though Cloudflare serves these paths
+        # directly at the Worker edge to avoid an expensive ASGI cold start.
+        convex_ticket = await client.post(
+            "/api/query",
+            json={"path": "auth/wsTickets:issueWebUserWsTicket"},
+        )
+        assert convex_ticket.status_code == 200, convex_ticket.text
+        convex_payload = convex_ticket.json()
+        assert convex_payload.get("status") == "success"
+        convex_token = (convex_payload.get("value") or {}).get("ticket")
+        assert isinstance(convex_token, str) and "." in convex_token
+        assert convex_payload.get("logLines") == []
+
+        preflight = await client.post(
+            "/api/mutation",
+            json={"path": "auth/otpEmail:preflightOtpSend"},
+        )
+        assert preflight.status_code == 200, preflight.text
+        assert preflight.json() == {
+            "status": "success",
+            "value": None,
+            "logLines": [],
+        }
+
+        timestamp = await client.post("/api/query_ts")
+        assert timestamp.status_code == 200, timestamp.text
+        assert timestamp.json() == {"ts": "0"}
+
+    print(
+        "[ok] FastAPI compatibility routes preserve entry, ticket, and Convex contracts"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes production `POST /api/query` requests being canceled as hung by Cloudflare Workers.

After #24 moved bootstrap-critical APIs off FastAPI, the shipped client still sends Convex-compatible HTTP RPCs to `/api/query`. Those requests were falling through to `asgi.fetch(...)`, cold-starting the full FastAPI/Pydantic stack and getting canceled before a response was produced.

### Fix
- intercept the full local Convex compatibility surface in `cloudflare/entry.py`
- parse request bodies with the native Workers `await request.json()` API
- preserve the existing response contract for:
  - `auth/wsTickets:issueWebUserWsTicket`
  - `auth/otpEmail:preflightOtpSend`
  - unsupported functions
  - `/api/query_ts`
- cover `/api/query`, `/api/mutation`, `/api/action`, `/api/function`, `/api/query_at_ts`, and `/api/query_ts`
- delegate all non-Convex requests to the existing `_runtime.Default`
- apply runtime bindings before issuing signed tickets so `SECRET_KEY` stays consistent

### Validation
- expands the real ASGI compatibility test to verify Convex ticket, OTP preflight, and query timestamp contracts
- adds a Cloudflare entry routing guard so all Convex paths must stay ahead of the ASGI fallback
- existing Hibernation, memory/CPU, AI, cache, local access gate, compile, and Wrangler dry-run checks remain enabled.