### PR TITLE
build: add manual Nuitka local distributions

### DIFF
--- a/.github/workflows/nuitka-local-build.yml
+++ b/.github/workflows/nuitka-local-build.yml
@@ -1,0 +1,55 @@
+name: Nuitka Local Build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Windows
+            os: windows-latest
+          - name: Linux
+            os: ubuntu-latest
+          - name: macOS
+            os: macos-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Sync local + Nuitka build dependencies
+        run: uv sync --extra local --group build --python 3.13
+
+      - name: Show Nuitka version
+        run: uv run python -m nuitka --version
+
+      - name: Build standalone distribution
+        run: uv run python scripts/build_nuitka.py
+
+      - name: Smoke test compiled distribution
+        run: uv run python scripts/smoke_nuitka.py
+
+      - name: Upload local distribution
+        uses: actions/upload-artifact@v4
+        with:
+          name: Nori.Web-${{ runner.os }}-${{ runner.arch }}
+          path: build/release/Nori.Web-*
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/LOCAL_NUITKA.md
+++ b/docs/LOCAL_NUITKA.md
@@ -1,0 +1,51 @@
+# Nuitka 本地发行包
+
+Nori.Web 可以使用 Nuitka 编译为无需目标机器预装 Python 的 standalone 本地发行目录。
+
+## 本地构建
+
+安装本地运行依赖与构建依赖：
+
+```bash
+uv sync --extra local --group build
+```
+
+构建：
+
+```bash
+uv run python scripts/build_nuitka.py
+```
+
+产物位于：
+
+```text
+build/release/Nori.Web-<system>-<architecture>/
+```
+
+启动目录中的 `Nori.Web`（Windows 为 `Nori.Web.exe`），然后访问：
+
+```text
+http://127.0.0.1:4173/
+```
+
+本地环境变量与直接运行 `python server.py` 时相同，例如 `OPENAI_API_KEY`、`OPENAI_BASE_URL`、`OPENAI_MODEL`、`HOST`、`PORT` 与 `NORI_DISABLE_LIVE_PACK`。
+
+## GitHub Actions 手动构建
+
+仓库提供 `.github/workflows/nuitka-local-build.yml`，仅支持手动触发，不会在普通 push 或 pull request 时自动消耗三平台编译时间。
+
+在 GitHub 仓库中打开 **Actions → Nuitka Local Build → Run workflow**。一次运行会分别在 Windows、Linux 与 macOS 的 GitHub-hosted runner 上进行原生编译。
+
+每个平台都会：
+
+1. 使用 Python 3.13 与 Nuitka 4.2；
+2. 以 standalone 模式编译本地服务；
+3. 将 `public/` 与 `backend/data/` 递归放入发行目录；
+4. 启动编译后的程序并检查 `/api/entry-status` 与 `/`；
+5. 上传 `Nori.Web-<OS>-<architecture>` artifact，保留 14 天。
+
+CI 产物未进行 Windows 代码签名或 Apple notarization，因此操作系统可能将下载的二进制标记为未签名应用。正式公开发布时建议另行加入签名流程。
+
+## 为什么先使用 standalone
+
+Nori.Web 包含较多前端、Live2D 与世界数据资源。standalone 目录可以直接访问这些随包资源，启动时也无需像 onefile 那样先展开整个资源包，更适合作为当前的本地发行形式。等三平台 standalone 经过实际用户验证后，再增加 onefile 作为可选发布格式会更稳妥。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
     "uvicorn[standard]>=0.30",
     "websockets>=13",
 ]
+build = [
+    "nuitka==4.2",
+]
 
 [tool.ruff]
 target-version = "py311"

--- a/scripts/build_nuitka.py
+++ b/scripts/build_nuitka.py
@@ -1,0 +1,108 @@
+"""Build a self-contained local Nori.Web distribution with Nuitka."""
+
+from __future__ import annotations
+
+import argparse
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+ENTRY = ROOT / "scripts" / "nuitka_entry.py"
+BUILD_ROOT = ROOT / "build" / "nuitka"
+RELEASE_ROOT = ROOT / "build" / "release"
+
+
+def _platform_tag() -> str:
+    system = platform.system().lower() or "unknown"
+    machine = platform.machine().lower().replace("amd64", "x86_64") or "unknown"
+    return f"{system}-{machine}"
+
+
+def _copy_release_metadata(release_dir: Path) -> None:
+    for name in ("README.md", "LICENSE"):
+        source = ROOT / name
+        if source.is_file():
+            shutil.copy2(source, release_dir / name)
+
+    info = release_dir / "BUILD_INFO.txt"
+    info.write_text(
+        "\n".join(
+            [
+                "Nori.Web Nuitka standalone distribution",
+                f"Platform: {platform.platform()}",
+                f"Architecture: {platform.machine()}",
+                f"Python: {platform.python_version()}",
+                "Build mode: standalone",
+                "Start the Nori.Web executable, then open http://127.0.0.1:4173/",
+                "Configuration is read from the same environment variables as the Python server.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def build(*, clean: bool = True) -> Path:
+    if clean:
+        shutil.rmtree(BUILD_ROOT, ignore_errors=True)
+        shutil.rmtree(RELEASE_ROOT, ignore_errors=True)
+
+    BUILD_ROOT.mkdir(parents=True, exist_ok=True)
+    RELEASE_ROOT.mkdir(parents=True, exist_ok=True)
+
+    binary_name = "Nori.Web.exe" if sys.platform == "win32" else "Nori.Web"
+    command = [
+        sys.executable,
+        "-m",
+        "nuitka",
+        "--mode=standalone",
+        "--assume-yes-for-downloads",
+        "--remove-output",
+        f"--output-dir={BUILD_ROOT}",
+        f"--output-filename={binary_name}",
+        f"--include-data-dir={ROOT / 'public'}=public",
+        f"--include-data-dir={ROOT / 'backend' / 'data'}=backend/data",
+        "--include-package=backend",
+        "--include-package=uvicorn",
+        "--include-package=websockets",
+        str(ENTRY),
+    ]
+
+    print("[nuitka]", " ".join(str(part) for part in command))
+    subprocess.run(command, cwd=ROOT, check=True)
+
+    nuitka_dist = BUILD_ROOT / "nuitka_entry.dist"
+    if not nuitka_dist.is_dir():
+        candidates = sorted(BUILD_ROOT.glob("*.dist"))
+        if len(candidates) != 1:
+            raise RuntimeError(f"Unable to locate Nuitka standalone output in {BUILD_ROOT}")
+        nuitka_dist = candidates[0]
+
+    release_dir = RELEASE_ROOT / f"Nori.Web-{_platform_tag()}"
+    shutil.copytree(nuitka_dist, release_dir)
+    _copy_release_metadata(release_dir)
+
+    executable = release_dir / binary_name
+    if not executable.is_file():
+        raise RuntimeError(f"Compiled executable is missing: {executable}")
+
+    print(f"[nuitka] release ready: {release_dir}")
+    return release_dir
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--no-clean",
+        action="store_true",
+        help="keep existing build directories before compiling",
+    )
+    args = parser.parse_args()
+    build(clean=not args.no_clean)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/nuitka_entry.py
+++ b/scripts/nuitka_entry.py
@@ -1,0 +1,25 @@
+"""Nuitka entrypoint for the self-contained local Nori.Web distribution."""
+
+from __future__ import annotations
+
+import uvicorn
+
+from backend.core.config import HOST, PORT
+from backend.virtual_apps import live_pack
+from server import app
+
+
+def main() -> None:
+    print(f"NoriOS local compatibility server: http://{HOST}:{PORT}")
+    print(f"Arcade WebSocket: ws://{HOST}:{PORT}/api/arcade/web/v1")
+    print(live_pack.summary())
+    print("Press Ctrl+C to stop the server.")
+
+    # The compiled distribution is a deployment artifact, not a development
+    # reloader. Passing the app object directly also avoids Uvicorn having to
+    # import a source module by name from inside a Nuitka standalone build.
+    uvicorn.run(app, host=HOST, port=PORT, reload=False)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/smoke_nuitka.py
+++ b/scripts/smoke_nuitka.py
@@ -1,0 +1,76 @@
+"""Launch the Nuitka distribution and verify its local HTTP surface."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RELEASE_ROOT = ROOT / "build" / "release"
+
+
+def _find_executable() -> Path:
+    release_dirs = [path for path in RELEASE_ROOT.glob("Nori.Web-*") if path.is_dir()]
+    if len(release_dirs) != 1:
+        raise RuntimeError(f"Expected one release directory under {RELEASE_ROOT}, found {release_dirs}")
+    binary = release_dirs[0] / ("Nori.Web.exe" if sys.platform == "win32" else "Nori.Web")
+    if not binary.is_file():
+        raise RuntimeError(f"Compiled executable not found: {binary}")
+    return binary
+
+
+def _wait_for(url: str, timeout: float = 60.0) -> bytes:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=3) as response:
+                if response.status == 200:
+                    return response.read()
+                last_error = RuntimeError(f"{url} returned HTTP {response.status}")
+        except (OSError, urllib.error.URLError) as exc:
+            last_error = exc
+        time.sleep(0.5)
+    raise RuntimeError(f"Timed out waiting for {url}: {last_error}")
+
+
+def main() -> None:
+    binary = _find_executable()
+    env = os.environ.copy()
+    env.update(
+        {
+            "HOST": "127.0.0.1",
+            "PORT": "4173",
+            # The smoke test checks the packaged runtime and static files; it
+            # does not need to deserialize the full optional archive.
+            "NORI_DISABLE_LIVE_PACK": "1",
+        }
+    )
+
+    process = subprocess.Popen([str(binary)], env=env)
+    try:
+        status = _wait_for("http://127.0.0.1:4173/api/entry-status")
+        if b'"status":"ok"' not in status and b'"status": "ok"' not in status:
+            raise RuntimeError(f"Unexpected entry-status payload: {status[:200]!r}")
+
+        index = _wait_for("http://127.0.0.1:4173/")
+        if b"<html" not in index.lower() and b"<!doctype html" not in index.lower():
+            raise RuntimeError("Packaged root response does not look like HTML")
+
+        print(f"[ok] compiled local distribution serves API + SPA: {binary}")
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=10)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds a reusable Nuitka local distribution pipeline for users who want to run Nori.Web without installing Python on the target machine.

### Nuitka build support
- adds a dedicated `build` dependency group with Nuitka 4.2
- adds `scripts/nuitka_entry.py` as a compiled-runtime launcher that passes the FastAPI app object directly to Uvicorn (no source-module reload/import requirement)
- adds `scripts/build_nuitka.py` for reproducible standalone builds
- recursively bundles `public/` and `backend/data/`, including the local live-world archive and frontend/Live2D assets
- explicitly follows the Nori backend, Uvicorn, and WebSockets packages
- writes build/platform metadata into each release directory

### Manual GitHub Actions
Adds `.github/workflows/nuitka-local-build.yml` with `workflow_dispatch` only.

A manual run builds natively on:
- Windows (`windows-latest`)
- Linux (`ubuntu-latest`)
- macOS (`macos-latest`)

Each job uses Python 3.13, builds a Nuitka standalone distribution, launches the compiled executable, verifies `/api/entry-status` and `/` return successfully, then uploads a platform/architecture-named artifact for 14 days.

### Documentation
Adds `docs/LOCAL_NUITKA.md` with local build commands, artifact usage, environment configuration, and unsigned-binary notes.

Standalone is intentional for the first release: Nori.Web carries a large static/Live2D/world-data tree, and Nuitka recommends validating standalone before moving to onefile.