### PR TITLE
tooling: add frontend bundle recovery pipeline

### DIFF
--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Verify browser runtime shim JavaScript
         run: node --check public/nori-runtime-shims.js
 
+      - name: Verify frontend recovery tool syntax
+        run: node --check scripts/recover_frontend.mjs
+
       - name: Compile Python sources
         run: uv run python -m compileall -q backend scripts server.py worker.py
 

--- a/.github/workflows/frontend-recovery.yml
+++ b/.github/workflows/frontend-recovery.yml
@@ -1,0 +1,57 @@
+name: Frontend Bundle Recovery
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref whose shipped frontend bundles should be recovered"
+        required: false
+        default: "master"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  recover:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout requested ref
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install frontend tooling
+        run: npm ci
+
+      - name: Recover shipped frontend bundles
+        run: npm run recover:frontend
+
+      - name: Show recovery summary
+        shell: bash
+        run: |
+          node - <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('recovered-src/manifest.json', 'utf8'));
+          console.log(`Recovered chunks: ${manifest.chunks.length}`);
+          console.log(`Exact source-map files: ${manifest.sourceMapRecoveredFiles}`);
+          console.log('Largest chunks:');
+          for (const chunk of manifest.chunks.slice(0, 15)) {
+            console.log(`  ${chunk.bundle}: ${chunk.bytes} bytes`);
+          }
+          NODE
+
+      - name: Upload recovered source tree
+        uses: actions/upload-artifact@v4
+        with:
+          name: Nori.Web-recovered-frontend-${{ github.run_number }}
+          path: recovered-src/
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 .research/
 data/*.sqlite3
 data/*.db
+recovered-src/
 
 # --- Cloudflare Python Workers ---
 .venv-workers/

--- a/docs/FRONTEND_RECOVERY.md
+++ b/docs/FRONTEND_RECOVERY.md
@@ -1,0 +1,57 @@
+# Frontend bundle recovery
+
+The repository currently ships the NoriOS frontend as Vite-generated JavaScript/CSS chunks under `public/assets/`. The recovery tooling turns those deployment artifacts into a readable source tree for maintenance and migration work.
+
+## Run locally
+
+```bash
+npm ci
+npm run recover:frontend
+```
+
+Generated files are written to `recovered-src/` and are ignored by Git.
+
+The output contains:
+
+- `original/` — exact `sourcesContent` recovered from source maps when a shipped chunk contains an inline/local map.
+- `chunks/` — syntax-preserving, deminified JavaScript for every shipped Vite chunk.
+- `reports/` — per-chunk dependency/export/symbol/string-hint reports.
+- `manifest.json` — machine-readable inventory sorted by original chunk size.
+- `MODULE_GRAPH.md` — first-pass static/dynamic chunk dependency graph.
+
+## Run with GitHub Actions
+
+Open **Actions → Frontend Bundle Recovery → Run workflow**. The workflow is manual-only (`workflow_dispatch`). It installs the existing frontend toolchain, runs the recovery command, and uploads `recovered-src/` as an artifact for 14 days.
+
+The optional `ref` input can point at another branch/tag/commit so different shipped frontend versions can be compared without modifying the recovery tool itself.
+
+## Recovery levels
+
+### Exact recovery
+
+If a chunk has a source map with `sourcesContent`, the original embedded files are copied to `recovered-src/original/`. File paths are sanitized before extraction.
+
+### Bundle-source recovery
+
+When source maps are absent, the JavaScript runtime semantics are still present in the Vite chunk. The tool parses/formats that JavaScript and records its module dependencies, exports and surviving symbol/string clues. This produces maintainable JavaScript, but it cannot uniquely recreate information that the minifier removed, including:
+
+- original TypeScript types/interfaces;
+- comments not present in the bundle;
+- original local variable names;
+- exact pre-bundle file boundaries;
+- JSX/TSX spelling when the bundle only contains compiled JSX calls.
+
+Those details are reconstructed in a second pass by using chunk names, imports/exports, React component signatures, state keys, API/event strings and behavior tests.
+
+## Recommended migration order
+
+1. Recover all chunks and keep `manifest.json` as the baseline.
+2. Start with small named chunks such as auth providers, panels and individual app screens.
+3. Give surviving components/hooks/stores stable semantic names.
+4. Move each understood module into a normal `src/` tree and add behavior tests against the shipped bundle.
+5. Tackle `NormalApp-*` last; it contains shared runtime/vendor/application code and benefits the most from symbols recovered from smaller chunks first.
+6. Once the reconstructed Vite build is behavior-compatible, replace `public/assets` bundle overrides gradually rather than in one large cutover.
+
+## Provenance
+
+Every generated chunk report includes the SHA-256 of the input asset. Keep that hash when documenting manual renames so a recovered module can always be traced back to the exact shipped bundle it was derived from.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build",
     "start": "python server.py",
     "start:py": "python server.py",
+    "recover:frontend": "node scripts/recover_frontend.mjs",
     "test:cartridges": "python tests/test_cartridges.py",
     "test:backend": "python tests/test_backend_integration.py",
     "test:virtual_apps": "python tests/test_virtual_apps.py",

--- a/scripts/recover_frontend.mjs
+++ b/scripts/recover_frontend.mjs
@@ -1,0 +1,267 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+import { js as beautify } from "js-beautify";
+import prettier from "prettier";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+function parseArgs(argv) {
+  const options = {
+    input: path.join(ROOT, "public", "assets"),
+    output: path.join(ROOT, "recovered-src"),
+    clean: true,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--input") options.input = path.resolve(argv[++index]);
+    else if (arg === "--output") options.output = path.resolve(argv[++index]);
+    else if (arg === "--no-clean") options.clean = false;
+    else if (arg === "--help" || arg === "-h") {
+      console.log(`Usage: node scripts/recover_frontend.mjs [options]\n\nOptions:\n  --input DIR     Bundle directory (default: public/assets)\n  --output DIR    Recovery output directory (default: recovered-src)\n  --no-clean      Keep files already present in the output directory\n`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function walk(dir) {
+  const out = [];
+  for (const entry of await readdir(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...(await walk(full)));
+    else out.push(full);
+  }
+  return out;
+}
+
+function sha256(text) {
+  return createHash("sha256").update(text).digest("hex");
+}
+
+function sanitizeSourcePath(value, fallback) {
+  let normalized = String(value || fallback)
+    .replace(/^webpack:\/\//, "")
+    .replace(/^vite:\/\//, "")
+    .replace(/^file:\/\//, "")
+    .replaceAll("\\", "/")
+    .replace(/^\/+/, "");
+
+  const parts = normalized.split("/").filter((part) => part && part !== "." && part !== "..");
+  normalized = parts.join("/");
+  return normalized || fallback;
+}
+
+async function loadSourceMap(bundlePath, source) {
+  const match = source.match(/(?:\/\/[#@]\s*sourceMappingURL=([^\s]+)|\/\*[#@]\s*sourceMappingURL=([^*]+)\*\/)[\s]*$/m);
+  if (!match) return null;
+
+  const ref = (match[1] || match[2] || "").trim();
+  if (!ref) return null;
+
+  try {
+    if (ref.startsWith("data:")) {
+      const comma = ref.indexOf(",");
+      if (comma < 0) return null;
+      const metadata = ref.slice(0, comma);
+      const payload = ref.slice(comma + 1);
+      const decoded = metadata.includes(";base64")
+        ? Buffer.from(payload, "base64").toString("utf8")
+        : decodeURIComponent(payload);
+      return { ref: "inline", map: JSON.parse(decoded) };
+    }
+
+    if (/^[a-z]+:\/\//i.test(ref)) {
+      return { ref, skipped: "remote source maps are intentionally not fetched" };
+    }
+
+    const mapPath = path.resolve(path.dirname(bundlePath), ref);
+    if (!existsSync(mapPath)) return { ref, skipped: "referenced source map is absent" };
+    return { ref, map: JSON.parse(await readFile(mapPath, "utf8")) };
+  } catch (error) {
+    return { ref, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+async function formatJavaScript(source) {
+  try {
+    return await prettier.format(source, {
+      parser: "babel",
+      printWidth: 100,
+      semi: true,
+      singleQuote: false,
+      trailingComma: "all",
+    });
+  } catch (prettierError) {
+    try {
+      return beautify(source, {
+        indent_size: 2,
+        preserve_newlines: true,
+        max_preserve_newlines: 2,
+        wrap_line_length: 100,
+      });
+    } catch {
+      throw prettierError;
+    }
+  }
+}
+
+function extractModuleInfo(formatted) {
+  const dependencies = new Set();
+  const dynamicDependencies = new Set();
+  const exports = new Set();
+  const topLevelSymbols = new Set();
+  const hints = new Set();
+
+  for (const match of formatted.matchAll(/(?:^|\n)\s*(?:import|export)\s+(?:[\s\S]*?\s+from\s+)?["']([^"']+)["']/g)) {
+    dependencies.add(match[1]);
+  }
+  for (const match of formatted.matchAll(/\bimport\(\s*["']([^"']+)["']\s*\)/g)) {
+    dynamicDependencies.add(match[1]);
+  }
+  for (const match of formatted.matchAll(/\bexport\s*\{([^}]+)\}/g)) {
+    for (const item of match[1].split(",")) {
+      const cleaned = item.trim();
+      if (!cleaned) continue;
+      const alias = cleaned.split(/\s+as\s+/i).at(-1)?.trim();
+      if (alias) exports.add(alias);
+    }
+  }
+  for (const match of formatted.matchAll(/(?:^|\n)(?:export\s+)?(?:async\s+)?(?:function|class|const|let|var)\s+([A-Za-z_$][\w$]*)/g)) {
+    topLevelSymbols.add(match[1]);
+  }
+
+  const stringPattern = /(["'`])((?:\\.|(?!\1)[^\\\n]){3,160})\1/g;
+  for (const match of formatted.matchAll(stringPattern)) {
+    const value = match[2];
+    if (
+      value.startsWith("/api/") ||
+      value.startsWith("ws://") ||
+      value.startsWith("wss://") ||
+      /(?:storage|session|localStorage|sessionStorage|arcade|manifold|nori\.|live2d|cartridge|world|ticket|auth)/i.test(value)
+    ) {
+      hints.add(value);
+    }
+    if (hints.size >= 250) break;
+  }
+
+  return {
+    dependencies: [...dependencies].sort(),
+    dynamicDependencies: [...dynamicDependencies].sort(),
+    exports: [...exports].sort(),
+    topLevelSymbols: [...topLevelSymbols].sort(),
+    hints: [...hints].sort(),
+  };
+}
+
+async function recoverSourceMapSources(mapResult, outputRoot, chunkName) {
+  const map = mapResult?.map;
+  if (!map || !Array.isArray(map.sources) || !Array.isArray(map.sourcesContent)) return [];
+
+  const recovered = [];
+  for (let index = 0; index < map.sources.length; index += 1) {
+    const content = map.sourcesContent[index];
+    if (typeof content !== "string") continue;
+
+    const fallback = `${chunkName}/source-${String(index).padStart(4, "0")}.js`;
+    const relative = sanitizeSourcePath(map.sources[index], fallback);
+    const destination = path.join(outputRoot, "original", relative);
+    await mkdir(path.dirname(destination), { recursive: true });
+    await writeFile(destination, content, "utf8");
+    recovered.push({ source: map.sources[index], output: path.relative(outputRoot, destination) });
+  }
+  return recovered;
+}
+
+function markdownEscape(value) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (!existsSync(options.input)) throw new Error(`Bundle directory does not exist: ${options.input}`);
+
+  if (options.clean) await rm(options.output, { recursive: true, force: true });
+  await mkdir(path.join(options.output, "chunks"), { recursive: true });
+  await mkdir(path.join(options.output, "reports"), { recursive: true });
+
+  const files = (await walk(options.input)).filter((file) => file.endsWith(".js")).sort();
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    input: path.relative(ROOT, options.input),
+    output: path.relative(ROOT, options.output),
+    chunks: [],
+    sourceMapRecoveredFiles: 0,
+  };
+
+  for (const bundlePath of files) {
+    const relativeBundle = path.relative(options.input, bundlePath).replaceAll(path.sep, "/");
+    const source = await readFile(bundlePath, "utf8");
+    const chunkName = path.basename(relativeBundle, ".js");
+    const sourceMap = await loadSourceMap(bundlePath, source);
+    const exactSources = await recoverSourceMapSources(sourceMap, options.output, chunkName);
+    manifest.sourceMapRecoveredFiles += exactSources.length;
+
+    const formatted = await formatJavaScript(source);
+    const recoveredPath = path.join(options.output, "chunks", relativeBundle);
+    await mkdir(path.dirname(recoveredPath), { recursive: true });
+    await writeFile(
+      recoveredPath,
+      `/* Recovered from public/assets/${relativeBundle}.\n * This is a syntax-preserving deminified bundle chunk, not necessarily the original TS/TSX module boundary.\n */\n\n${formatted}`,
+      "utf8",
+    );
+
+    const moduleInfo = extractModuleInfo(formatted);
+    const report = {
+      bundle: relativeBundle,
+      bytes: Buffer.byteLength(source),
+      sha256: sha256(source),
+      sourceMap: sourceMap
+        ? {
+            reference: sourceMap.ref,
+            recoveredFiles: exactSources.length,
+            skipped: sourceMap.skipped,
+            error: sourceMap.error,
+          }
+        : null,
+      exactSources,
+      ...moduleInfo,
+    };
+
+    const reportPath = path.join(options.output, "reports", `${chunkName}.json`);
+    await writeFile(reportPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+    manifest.chunks.push(report);
+    console.log(`[recover] ${relativeBundle}: ${report.bytes} bytes, ${moduleInfo.dependencies.length} deps, ${exactSources.length} map sources`);
+  }
+
+  manifest.chunks.sort((a, b) => b.bytes - a.bytes);
+  await writeFile(path.join(options.output, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+
+  const rows = manifest.chunks.map((chunk) => {
+    const deps = [...chunk.dependencies, ...chunk.dynamicDependencies.map((item) => `${item} (dynamic)`)].join(", ");
+    return `| ${markdownEscape(chunk.bundle)} | ${chunk.bytes.toLocaleString("en-US")} | ${chunk.sourceMap?.recoveredFiles ?? 0} | ${markdownEscape(deps || "-")} |`;
+  });
+  const graph = `# Recovered frontend chunk graph\n\nGenerated by \`scripts/recover_frontend.mjs\`.\n\n| Chunk | Bytes | Exact source-map files | Dependencies |\n| --- | ---: | ---: | --- |\n${rows.join("\n")}\n`;
+  await writeFile(path.join(options.output, "MODULE_GRAPH.md"), graph, "utf8");
+
+  const notes = `# Frontend recovery output\n\nThis directory is generated and intentionally ignored by Git.\n\n- \`original/\` contains exact \`sourcesContent\` recovered from source maps when present.\n- \`chunks/\` contains syntax-preserving deminified JavaScript for every shipped Vite chunk.\n- \`reports/\` records imports, dynamic imports, exports, top-level symbol names, string hints and hashes.\n- \`manifest.json\` is the machine-readable recovery index.\n- \`MODULE_GRAPH.md\` is the first-pass chunk dependency graph.\n\nWhen no source map is present, JavaScript semantics can be recovered but original TypeScript types, comments, file boundaries and pre-minification local identifier names are not uniquely recoverable from the bundle alone. Use the generated reports as the basis for the second-pass component/Hook/store renaming work.\n`;
+  await writeFile(path.join(options.output, "README.md"), notes, "utf8");
+
+  console.log(`\nRecovered ${manifest.chunks.length} JavaScript chunks into ${options.output}`);
+  console.log(`Exact source-map source files recovered: ${manifest.sourceMapRecoveredFiles}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Adds a reproducible frontend bundle recovery pipeline for the shipped Vite assets so the frontend can be inspected and migrated into maintainable source modules.

### Recovery tool
- adds `scripts/recover_frontend.mjs`
- scans every JavaScript chunk under `public/assets`
- prefers exact `sourcesContent` extraction when inline/local source maps are present
- otherwise produces syntax-preserving deminified JavaScript using the existing Prettier/js-beautify toolchain
- records static/dynamic dependencies, exports, top-level symbols, API/storage/event string hints and SHA-256 provenance for every chunk
- writes `manifest.json`, per-chunk reports and a Markdown module graph

### Manual workflow
Adds `.github/workflows/frontend-recovery.yml` with `workflow_dispatch` only. A manual run can target a branch/tag/commit and uploads the generated `recovered-src/` tree as a 14-day artifact.

### Repository integration
- adds `npm run recover:frontend`
- ignores generated `recovered-src/`
- adds `docs/FRONTEND_RECOVERY.md`
- syntax-checks the recovery tool in the existing CI without adding npm-install overhead to the Cloudflare job

The generated tree distinguishes exact source-map recovery from deminified bundle-source recovery so inferred structure is not presented as original TS/TSX provenance.