### PR TITLE
fix(cloudflare): preserve dashboard-managed domains and routes

### DIFF
--- a/tests/test_cloudflare_builds_deploy.py
+++ b/tests/test_cloudflare_builds_deploy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -15,6 +16,22 @@ spec.loader.exec_module(module)
 
 
 def main() -> None:
+    # Domains and routes are intentionally managed in the Cloudflare dashboard.
+    # Wrangler must not re-declare them during deploy, or every merge will
+    # overwrite dashboard changes. Cloudflare also requires workers_dev=false
+    # for dashboard-only route management.
+    wrangler_config = (ROOT / "wrangler.jsonc").read_text(encoding="utf-8")
+    assert re.search(
+        r'^\s*"workers_dev"\s*:\s*false\s*,?\s*$',
+        wrangler_config,
+        re.MULTILINE,
+    )
+    assert re.search(
+        r'^\s*"routes?"\s*:',
+        wrangler_config,
+        re.MULTILINE,
+    ) is None
+
     # Workers Builds already supplies Python. A repository .python-version makes
     # Cloudflare's environment manager install another interpreter before every
     # production deploy, which was the largest observed build-time cost.
@@ -109,7 +126,7 @@ def main() -> None:
         module.deploy_worker = original_deploy
 
     print(
-        "[ok] Workers Builds deploy fingerprint, bundled Python, CI mode, and single-stage runtime path behave correctly"
+        "[ok] Workers Builds deploy fingerprint, dashboard routing, bundled Python, CI mode, and single-stage runtime path behave correctly"
     )
 
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,7 +4,7 @@
   "main": "cloudflare/entry.py",
   "compatibility_date": "2026-08-28",
   "compatibility_flags": ["python_workers"],
-  "workers_dev": true,
+  "workers_dev": false,
   "preview_urls": true,
   "base_dir": "./cloudflare",
   "find_additional_modules": true,
@@ -43,12 +43,8 @@
   "placement": {
     "mode": "smart"
   },
-  "routes": [
-    {
-      "pattern": "nori-expermintal.088092111.xyz",
-      "custom_domain": true
-    }
-  ],
+  // Domains and routing are intentionally managed in the Cloudflare dashboard.
+  // Keep route configuration absent here so Wrangler deploys do not overwrite it.
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary

- stop declaring Worker `route` / `routes` in `wrangler.jsonc`
- set `workers_dev` to `false` so Cloudflare Dashboard remains the source of truth for Domains & Routes
- add a regression assertion to the Workers Builds deployment test so future changes cannot silently reintroduce Wrangler-managed routing

## Why

Cloudflare documents that routes changed in the Dashboard are overwritten on the next Wrangler deployment when `route` or `routes` is present in Wrangler configuration. Nori.Web deploys via `pywrangler deploy` after merges, so the repository route declaration was re-applying routing on every production deploy.

After this change, custom domains and routes should be configured under Cloudflare Dashboard → Worker → Settings → Domains & Routes and will no longer be rewritten by normal repository deployments.

## Notes

- Worker code, Assets, R2, Durable Object bindings, migrations, observability, placement, and non-secret vars remain source-managed in `wrangler.jsonc`.
- Preview URLs remain enabled.
- This PR does not merge automatically.