### PR TITLE
fix: restore glass background in AI and TTS settings

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,6 +23,9 @@
     <script src="/nori-ai-settings.js"></script>
     <script src="/nori-ai-provider-switch.js"></script>
     <script src="/nori-tts-settings.js"></script>
+    <!-- Keep the compatibility panels visually consistent with the native
+         Settings pages by letting the Nori window glass show through. -->
+    <link rel="stylesheet" href="/nori-settings-glass.css" />
     <!-- No model warmup here: dev-bypass preloads via preloadLive2DModel in
          main.tsx (fetch + decode + stage, strictly stronger than an HTTP
          warmer and not duplicated — fetch() does not coalesce identical

--- a/public/nori-settings-glass.css
+++ b/public/nori-settings-glass.css
@@ -1,0 +1,9 @@
+/*
+ * Compatibility settings panels are injected beside the historical Settings
+ * content. Keep them transparent so the parent Nori window glass remains
+ * visible instead of covering it with the opaque --background token.
+ */
+html.theme-nori .nori-ai-settings-panel,
+html.theme-nori .nori-tts-panel {
+  background: transparent;
+}


### PR DESCRIPTION
## Summary

Restores the native Nori glass appearance for the compatibility AI and TTS Settings panels.

The injected panels were painting `var(--background)` across the full content area. In the Nori theme that token is opaque, so it covered the existing window glass layer and made AI/TTS look flatter than the other Settings pages.

This change keeps those compatibility panels transparent and lets the existing `nori-window-glass` blur/saturation layer remain visible. The override stylesheet is loaded after the compatibility scripts so it wins the injected panel background rules without adding a second blur pass.

## Scope

- AI Settings visual background only
- TTS Settings visual background only
- No provider/config/runtime behavior changes
- No changes to the native Settings pages or window glass implementation