### PR TITLE
fix: prevent Cake Duel agent soft-lock after pass

### DIFF
--- a/backend/session/world.py
+++ b/backend/session/world.py
@@ -47,6 +47,7 @@ class WorldSession:
         self.event_dispatcher = EventDispatcher(self)
         self._media_sequence = 0
         self._tasks: Set[asyncio.Task[Any]] = set()
+        self._agent_tasks: Dict[str, asyncio.Task[Any]] = {}
 
     def issue_media_grant(self) -> str:
         grant = secrets.token_urlsafe(32)
@@ -142,10 +143,87 @@ class WorldSession:
         await self.broadcast(messages)
         return commit
 
-    def _spawn(self, coroutine: Any) -> None:
+    def _spawn(self, coroutine: Any) -> asyncio.Task[Any]:
         task = asyncio.create_task(coroutine)
         self._tasks.add(task)
-        task.add_done_callback(self._tasks.discard)
+
+        def finish(completed: asyncio.Task[Any]) -> None:
+            self._tasks.discard(completed)
+            if completed.cancelled():
+                return
+            error = completed.exception()
+            if error is not None:
+                print(f"[world:{self.world_id}] background task failed: {error}")
+
+        task.add_done_callback(finish)
+        return task
+
+    @staticmethod
+    def _cakeduel_recovery_command(cartridge: BaseCartridge) -> Optional[Dict[str, Json]]:
+        """Return a legal fail-safe when Cake Duel is stranded on Nori's turn."""
+        game = cartridge.state.get("game")
+        if not isinstance(game, dict) or game.get("gameEnded"):
+            return None
+        phase = game.get("phase")
+        attacker = game.get("attackerIndex")
+        if phase == "attack":
+            agent_turn = attacker == 1
+        elif phase == "block":
+            agent_turn = attacker == 0
+        elif phase == "review":
+            agent_turn = attacker == 1
+        else:
+            agent_turn = False
+        if not agent_turn:
+            return None
+        return {"type": "play", "action": {"type": "pass"}}
+
+    def _agent_recovery_command(self, cartridge_id: str, cartridge: BaseCartridge) -> Optional[Dict[str, Json]]:
+        if cartridge_id == "cakeduel":
+            return self._cakeduel_recovery_command(cartridge)
+        return None
+
+    def _next_agent_command(self, cartridge_id: str, cartridge: BaseCartridge) -> Optional[Dict[str, Json]]:
+        generator = getattr(cartridge, "agent_next_command", None)
+        try:
+            command = generator() if callable(generator) else None
+        except Exception as exc:
+            print(f"[world:{self.world_id}] {cartridge_id} agent decision failed: {exc}")
+            command = None
+        if command:
+            return command
+        recovery = self._agent_recovery_command(cartridge_id, cartridge)
+        if recovery is not None:
+            print(f"[world:{self.world_id}] recovering stranded {cartridge_id} agent turn with pass")
+        return recovery
+
+    async def _dispatch_agent_command(
+        self,
+        cartridge_id: str,
+        cartridge: BaseCartridge,
+        command: Dict[str, Json],
+    ) -> Optional[Any]:
+        commit = await self._dispatch_internal(cartridge_id, "agent", command)
+        if commit is not None:
+            return commit
+        recovery = self._agent_recovery_command(cartridge_id, cartridge)
+        if recovery is None or recovery == command:
+            return None
+        print(f"[world:{self.world_id}] retrying rejected {cartridge_id} agent action with pass")
+        return await self._dispatch_internal(cartridge_id, "agent", recovery)
+
+    def _schedule_agent_turns(self, cartridge_id: str) -> None:
+        existing = self._agent_tasks.get(cartridge_id)
+        if existing is not None and not existing.done():
+            return
+        task = self._spawn(self._run_agent_turns(cartridge_id))
+        self._agent_tasks[cartridge_id] = task
+
+        def clear(completed: asyncio.Task[Any]) -> None:
+            if self._agent_tasks.get(cartridge_id) is completed:
+                self._agent_tasks.pop(cartridge_id, None)
+
+        task.add_done_callback(clear)
 
     async def _run_chat_reply(self, user_text: str) -> None:
         chat = self.cartridges.get("chat")
@@ -199,10 +277,10 @@ class WorldSession:
             cartridge = self.cartridges.get(cartridge_id)
             if cartridge is None:
                 return
-            command = getattr(cartridge, "agent_next_command", lambda: None)()
+            command = self._next_agent_command(cartridge_id, cartridge)
             if not command:
                 return
-            commit = await self._dispatch_internal(cartridge_id, "agent", command)
+            commit = await self._dispatch_agent_command(cartridge_id, cartridge, command)
             if commit is None:
                 return
 
@@ -224,7 +302,7 @@ class WorldSession:
                 self._spawn(self._settle_chat_after_audio(cmd["operationId"]))
             return
         if cartridge_id in {"cakeduel", "codenames", "chess"}:
-            self._spawn(self._run_agent_turns(cartridge_id))
+            self._schedule_agent_turns(cartridge_id)
         elif cartridge_id == "pictionary" and command_type in {"submitGuess", "skipRound"}:
             self._spawn(self._start_next_pictionary_round())
 

--- a/cloudflare/entry.py
+++ b/cloudflare/entry.py
@@ -245,10 +245,10 @@ async def _cloudflare_run_agent_turns(self, cartridge_id: str) -> None:
         cartridge = self.cartridges.get(cartridge_id)
         if cartridge is None:
             return
-        command = getattr(cartridge, "agent_next_command", lambda: None)()
+        command = self._next_agent_command(cartridge_id, cartridge)
         if not command:
             return
-        commit = await self._dispatch_internal(cartridge_id, "agent", command)
+        commit = await self._dispatch_agent_command(cartridge_id, cartridge, command)
         if commit is None:
             return
 

--- a/tests/test_do_active_window_pacing.py
+++ b/tests/test_do_active_window_pacing.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
 
 from backend.cartridges.cakeduel import CakeDuelCartridge
 from backend.session.world import WorldSession
 
-ROOT = Path(__file__).resolve().parent.parent
 ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
 WORLD = (ROOT / "backend" / "session" / "world.py").read_text(encoding="utf-8")
 

--- a/tests/test_do_active_window_pacing.py
+++ b/tests/test_do_active_window_pacing.py
@@ -2,9 +2,57 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from backend.cartridges.cakeduel import CakeDuelCartridge
+from backend.session.world import WorldSession
+
 ROOT = Path(__file__).resolve().parent.parent
 ENTRY = (ROOT / "cloudflare" / "entry.py").read_text(encoding="utf-8")
 WORLD = (ROOT / "backend" / "session" / "world.py").read_text(encoding="utf-8")
+
+
+def verify_cakeduel_pass_recovery() -> None:
+    """A missing Nori decision after the player's pass must not soft-lock the duel."""
+    cartridge = CakeDuelCartridge()
+    cartridge.dispatch(
+        "player",
+        {"type": "startGame", "mode": "normal", "difficulty": "soldier"},
+    )
+
+    game = cartridge.state["game"]
+    claim_action = next(item for item in cartridge._legal_actions(game) if item["type"] == "claim")
+    cartridge.dispatch(
+        "player",
+        {
+            "type": "play",
+            "action": {
+                "type": "claim",
+                "handIndices": [0],
+                "claim": claim_action["claimFrom"][0],
+            },
+        },
+    )
+
+    block_command = cartridge.agent_next_command()
+    assert block_command is not None
+    cartridge.dispatch("agent", block_command)
+    assert cartridge.state["game"]["phase"] == "review"
+
+    cartridge.dispatch("player", {"type": "play", "action": {"type": "pass"}})
+    game = cartridge.state["game"]
+    assert game["phase"] == "attack" and game["attackerIndex"] == 1
+
+    # Reproduce the reported failure mode: the agent runner wakes up while the
+    # state says Nori is attacking, but the decision provider yields no action.
+    cartridge.agent_next_command = lambda: None  # type: ignore[method-assign]
+    world = WorldSession("cake-duel-recovery-test")
+    world.cartridges["cakeduel"] = cartridge
+
+    recovery = world._next_agent_command("cakeduel", cartridge)
+    assert recovery == {"type": "play", "action": {"type": "pass"}}
+    cartridge.dispatch("agent", recovery)
+
+    game = cartridge.state["game"]
+    assert game["phase"] == "attack" and game["attackerIndex"] == 0
 
 
 def main() -> None:
@@ -13,6 +61,12 @@ def main() -> None:
     assert "await asyncio.sleep(0.35)" in WORLD
     assert "await asyncio.sleep(1.2)" in WORLD
     assert "await asyncio.sleep(1.1)" in WORLD
+
+    # Game follow-ups are single-flight per cartridge and background failures
+    # are observed instead of disappearing from the task set silently.
+    assert "self._agent_tasks" in WORLD
+    assert "self._schedule_agent_turns(cartridge_id)" in WORLD
+    assert "background task failed" in WORLD
 
     # Cloudflare replaces only the presentation-only methods so Durable Object
     # active wall-clock time is not spent sleeping for UI pacing.
@@ -35,12 +89,16 @@ def main() -> None:
     assert chat_reply.count("self._spawn(self._ensure_chat_progress") == 1
 
     # Cloudflare-specific game follow-ups may cooperatively yield, but they must
-    # not reintroduce real presentation timers that extend DO duration.
+    # not reintroduce real presentation timers that extend DO duration. The
+    # production runner must use the guarded decision/dispatch helpers too.
     assert "await _runtime.asyncio.sleep(0)" in ENTRY
+    assert "self._next_agent_command(cartridge_id, cartridge)" in ENTRY
+    assert "self._dispatch_agent_command(cartridge_id, cartridge, command)" in ENTRY
     for delay in ("sleep(0.15)", "sleep(0.1)", "sleep(0.35)", "sleep(1.2)"):
         assert delay not in ENTRY
 
-    print("[ok] Cloudflare DO follow-ups preserve ordering without billed presentation waits")
+    verify_cakeduel_pass_recovery()
+    print("[ok] Cloudflare DO follow-ups preserve ordering and Cake Duel recovers stranded Nori turns")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fix the Cake Duel soft-lock reported when the player resolves an attack with **Pass**, the UI advances to **Nori attacking**, but Nori never produces the next action.

This hardens the shared Arcade agent runner and the Cloudflare zero-delay production runner:

- keep at most one agent-turn task active per cartridge;
- observe background-task failures instead of silently discarding completed tasks;
- route both local and Cloudflare game runners through guarded agent decision/dispatch helpers;
- add a Cake Duel fail-safe: if Nori is the phasing player but the decision provider returns no command, throws, or emits a rejected action, fall back to the always-legal `pass` action for attack/block/review phases so the duel cannot remain permanently stranded on Nori's turn;
- preserve normal Nori strategy whenever the normal decision succeeds.

## Regression coverage

`tests/test_do_active_window_pacing.py` now reproduces the reported sequence:

1. player starts Cake Duel;
2. player submits an attack claim;
3. Nori responds;
4. player passes to resolve the attack;
5. state advances to `phase=attack`, `attackerIndex=1`;
6. the test forces `agent_next_command()` to return `None`;
7. the guarded runner produces a legal pass fallback and the turn advances back to the player.

The existing Cloudflare pacing assertions also verify production keeps `sleep(0)` and uses the guarded helper path, so the fix does not reintroduce billed presentation delays.

## Scope

This PR is intentionally separate from the ongoing frontend recovery work and does not modify the historical Cake Duel frontend bundle.