### PR TITLE
fix(backend): send changedArtifactTypes on the channel the client reads

### DIFF
--- a/backend/cartridges/manifold.py
+++ b/backend/cartridges/manifold.py
@@ -99,14 +99,29 @@ def _fact_record(fact_id: str, actor: str, source: str, now_ms: int) -> Dict[str
     }
 
 
-def _affected_artifact_type(fact_id: str) -> Optional[str]:
+def _affected_artifact_types(fact_id: str) -> List[str]:
+    """Artifact list(s) whose contents a fact may change.
+
+    Sent on ``manifold.facts.changed`` as ``changedArtifactTypes``. An empty list
+    means "unknown", and the client then refreshes every list, so a missing entry
+    costs bandwidth but never correctness.
+
+    Signal facts touch both lists: a thread is only useful once its messages are
+    refreshed too, and the pack ships the two as separate artifact types
+    (``signal_thread_artifacts`` / ``signal_message_artifacts``).
+
+    Both ``signal.`` and ``signal_`` are matched. The unlock fact for the Messages
+    app is ``signal_daniel.unlocked`` (underscore); the per-thread read facts are
+    ``signal.daniel.read`` (dot). Matching only the dotted form left the unlock
+    itself mapped to nothing.
+    """
     if fact_id.startswith("mail."):
-        return "mail"
+        return ["mail"]
     if fact_id.startswith("file.") or fact_id.startswith("recover."):
-        return "file"
-    if fact_id.startswith("signal."):
-        return "signal_thread"
-    return None
+        return ["file"]
+    if fact_id.startswith("signal.") or fact_id.startswith("signal_"):
+        return ["signal_thread", "signal_message"]
+    return []
 
 
 def chip_config_of(variables: Dict[str, Any]) -> Dict[str, Any]:
@@ -204,19 +219,21 @@ class ManifoldWebCartridge(BaseCartridge):
                         int(cmd.get("emittedAt") or time.time() * 1000),
                     )
                     events.append({"type": "factEmitted", "factId": fact_id, "source": source})
-                    events.append({
+                    # The shipped client reads changedArtifactTypes off
+                    # manifold.facts.changed; the payload schema for
+                    # manifold.artifacts.invalidated is {reason} alone. Carrying the
+                    # value on the latter meant it never reached the client, which
+                    # then took its untargeted refresh path on every fact.
+                    facts_changed: Dict[str, Any] = {
                         "type": "manifold.facts.changed",
                         "emitted": [fact_id],
                         "retracted": [],
                         "snapshot": {fact_id: True},
-                    })
-                    art_type = _affected_artifact_type(fact_id)
-                    if art_type:
-                        events.append({
-                            "type": "manifold.artifacts.invalidated",
-                            "reason": f"fact:{fact_id}",
-                            "changedArtifactTypes": [art_type],
-                        })
+                    }
+                    changed = _affected_artifact_types(fact_id)
+                    if changed:
+                        facts_changed["changedArtifactTypes"] = changed
+                    events.append(facts_changed)
             return ReducerResult(state, {"ok": True}, events)
 
         APP_PREFIX = {"browser": "page", "files": "file", "mail": "mail",
@@ -335,19 +352,21 @@ class ManifoldWebCartridge(BaseCartridge):
                         int(cmd.get("emittedAt") or time.time() * 1000),
                     )
                     events.append({"type": "factEmitted", "factId": fact_id, "source": source})
-                    events.append({
+                    # The shipped client reads changedArtifactTypes off
+                    # manifold.facts.changed; the payload schema for
+                    # manifold.artifacts.invalidated is {reason} alone. Carrying the
+                    # value on the latter meant it never reached the client, which
+                    # then took its untargeted refresh path on every fact.
+                    facts_changed: Dict[str, Any] = {
                         "type": "manifold.facts.changed",
                         "emitted": [fact_id],
                         "retracted": [],
                         "snapshot": {fact_id: True},
-                    })
-                    art_type = _affected_artifact_type(fact_id)
-                    if art_type:
-                        events.append({
-                            "type": "manifold.artifacts.invalidated",
-                            "reason": f"fact:{fact_id}",
-                            "changedArtifactTypes": [art_type],
-                        })
+                    }
+                    changed = _affected_artifact_types(fact_id)
+                    if changed:
+                        facts_changed["changedArtifactTypes"] = changed
+                    events.append(facts_changed)
             return ReducerResult(state, {"ok": True}, events)
 
         if command_type == "chip.scan":

--- a/tests/test_cartridges.py
+++ b/tests/test_cartridges.py
@@ -161,6 +161,39 @@ def test_manifold() -> None:
     assert isinstance(sync_res.result, dict) and "prestige" in sync_res.result
 
 
+def test_manifold_changed_artifact_types() -> None:
+    """changedArtifactTypes must ride on manifold.facts.changed.
+
+    The shipped client declares the field on that channel; the payload schema for
+    manifold.artifacts.invalidated is {reason} alone, so a value carried there is
+    never seen and the client falls back to refreshing every artifact list.
+    """
+
+    def emit(fact_id: str) -> dict:
+        cartridge = ManifoldWebCartridge()
+        res = cartridge.dispatch("player", {"type": "client.emitFact", "factId": fact_id})
+        assert res.committed is True
+        events = (res.transition or {}).get("events") or []
+        changed = [e for e in events if e.get("type") == "manifold.facts.changed"]
+        assert len(changed) == 1, f"{fact_id}: expected one facts.changed, got {len(changed)}"
+        return changed[0]
+
+    # Synthetic ids so the assertions do not depend on which facts the shipped
+    # pack happens to pre-unlock (client.emitFact is a no-op for a known fact).
+    assert emit("mail.pr_probe.unlocked")["changedArtifactTypes"] == ["mail"]
+    assert emit("file.pr_probe.read")["changedArtifactTypes"] == ["file"]
+    assert emit("recover.pr_probe")["changedArtifactTypes"] == ["file"]
+
+    # Threads are useless without their messages; both lists are refreshed. The
+    # dotted and underscored spellings both occur in the pack.
+    for fact_id in ("signal.pr_probe.read", "signal_pr_probe.unlocked"):
+        assert emit(fact_id)["changedArtifactTypes"] == ["signal_thread", "signal_message"], fact_id
+
+    # Unknown prefix: omit the hint rather than guess. The client then refreshes
+    # every list, which is correct but untargeted.
+    assert "changedArtifactTypes" not in emit("arg.pr_probe")
+
+
 if __name__ == "__main__":
     test_registry()
     test_chat()
@@ -169,4 +202,5 @@ if __name__ == "__main__":
     test_chess()
     test_pictionary()
     test_manifold()
+    test_manifold_changed_artifact_types()
     print("[ok] chat, codenames, cakeduel, chess, pictionary, manifold.web, and registry verified")


### PR DESCRIPTION
## What

`client.emitFact` computes which artifact list a fact affects, then sends that
value on a channel the client does not read it from.

## Evidence

From the shipped parser in `public/assets/NormalApp-Cn6agT0F.js`, the two payload
schemas sit next to each other:

```js
Gbe = Ue({
  emitted: Ir(je()),
  retracted: Ir(je()),
  snapshot: Ph(je(), ac()),
  seeded: ac().optional(),
  fireFacts: Ir(je()).optional(),
  changedArtifactTypes: Ir(je()).optional(),   // <- declared here
}),
jbe = Xt("manifold.facts.changed", Gbe),
Hbe = Ue({ reason: je() }),                     // <- {reason} alone
zbe = Xt("manifold.artifacts.invalidated", Hbe);
```

and the handlers in the same bundle:

```js
E.onEvent(jbe, (M) => { ...; const A = M.changedArtifactTypes; A ? h(A) : f(); }),
E.onEvent(zbe, () => { f(); })
```

`facts.changed` takes the targeted path when the hint is present and the
untargeted one when it is absent. `artifacts.invalidated` always takes the
untargeted one.

`backend/cartridges/manifold.py` put the hint on `artifacts.invalidated`, so:

- the computed value never reached the client — every fact took the untargeted
  path;
- a fact with a known artifact type produced **two** refresh signals rather than
  one (`facts.changed` with no hint, then `artifacts.invalidated`).

Nothing was broken — the untargeted refresh is a superset — but the targeted
path was unreachable and mapped facts refreshed twice.

## Change

- Move `changedArtifactTypes` onto `manifold.facts.changed`; drop the now
  redundant `manifold.artifacts.invalidated` emission for the same fact.
- Omit the field for an unknown prefix instead of guessing, which leaves the
  client on its existing full-refresh path.
- Widen the mapping, observable only now that the hint is delivered:
  - signal facts refresh `signal_message` as well as `signal_thread`. A thread is
    not useful until its messages are refreshed too, and the pack ships them as
    separate artifact types (`signal_thread_artifacts` /
    `signal_message_artifacts`, 6 and 36 entries).
  - match `signal_` alongside `signal.`. The Messages unlock fact is
    `signal_daniel.unlocked` (underscore), which previously mapped to nothing.

The emit block is duplicated at two dispatch sites in that file; both are
updated identically. Happy to fold them into one helper in a follow-up if you
would prefer that separately.

## Why it matters

A full refresh is one request per artifact type. On a server with a per-account
fetch limiter, untargeted refreshes are what push a session over the threshold —
we hit exactly that on our own deployment and traced it back to refresh
amplification. Targeted invalidation is the mechanism this code already intended
to use.

## Tests

`tests/test_cartridges.py::test_manifold_changed_artifact_types` pins the
placement and the mapping. On the previous code it fails with:

```
KeyError: 'changedArtifactTypes'
```

Verified green after the change:

```
python tests/test_cartridges.py           [ok]
python tests/test_virtual_apps.py         [ok]
python tests/test_live_backend_logic.py   [ok]
python tests/test_live_pack_runtime.py    [ok]
python tests/test_backend_integration.py  [ok]
node   tests/test_client_schema.mjs       [ok] 17 envelopes
```

