### PR TITLE
test(schema): pin strictness and optional fields of the shipped parser

### DIFF
--- a/tests/test_client_schema.mjs
+++ b/tests/test_client_schema.mjs
@@ -37,4 +37,51 @@ for (const message of samples) {
   const result = parseServerMessage(message);
   if (!result.success) throw new Error(`${message.type}: ${JSON.stringify(result.error.issues)}`);
 }
-console.log(`[ok] ${samples.length} local message envelopes accepted by shipped parser`);
+
+// The samples above only prove that valid envelopes pass. The parser is strict,
+// and that strictness is what makes a malformed envelope fail *silently*: the
+// message is dropped and nothing reaches the UI, with no error surfaced to the
+// player. These cases pin the two ways that happens, so a regression shows up
+// here rather than as an unexplained frozen screen.
+const rejections = [
+  [
+    "extra key",
+    { type: "pong", serverId: "nori-local-arcade", now: 1, timestamp: 1 },
+  ],
+  [
+    "missing required key",
+    { type: "pong", now: 1 },
+  ],
+  [
+    "extra key on a discriminated variant",
+    { type: "dispatch_ack", worldId: "world", cartridgeId: "chat", requestId: "r", success: true, committed: true, committedVersion: 1, headVersion: 1, result: {}, serverId: "x" },
+  ],
+  [
+    "unknown message type",
+    { type: "definitely_not_a_message", worldId: "world" },
+  ],
+];
+
+for (const [label, message] of rejections) {
+  if (parseServerMessage(message).success) {
+    throw new Error(`expected rejection (${label}): ${JSON.stringify(message)}`);
+  }
+}
+
+// Optional fields must stay optional, so omitting one is not mistaken for a bug.
+const optional = [
+  ["pong without now", { type: "pong", serverId: "nori-local-arcade" }],
+  ["event without payload", { type: "event", worldId: "world", channel: "manifold.chip.status.result", cartridgeId: "chat", requestId: "r" }],
+];
+
+for (const [label, message] of optional) {
+  const result = parseServerMessage(message);
+  if (!result.success) {
+    throw new Error(`expected acceptance (${label}): ${JSON.stringify(result.error.issues)}`);
+  }
+}
+
+console.log(
+  `[ok] ${samples.length} local message envelopes accepted, ` +
+    `${rejections.length} malformed rejected, ${optional.length} optional-field shapes accepted`,
+);


### PR DESCRIPTION
## What

`tests/test_client_schema.mjs` validates 17 hand-written envelopes against the
shipped parser. That proves valid shapes pass; nothing yet pins what happens to
an invalid one.

That gap matters more here than in most schema tests. The parser is strict, so a
malformed envelope is not reported — it is dropped. The player-visible symptom is
a screen that stops updating with no error anywhere, which is expensive to trace
back to a single extra field on a single message.

## Change

Four rejection cases and two acceptance cases, in the existing style:

| case | expected |
| --- | --- |
| `pong` with an extra `timestamp` | rejected (`unrecognized_keys`) |
| `pong` without `serverId` | rejected (`invalid_type`) |
| `dispatch_ack` with an extra `serverId` | rejected (`invalid_union`) |
| unknown `type` | rejected |
| `pong` without `now` | accepted — `now` is optional |
| `event` without `payload` | accepted — `payload` is optional |

The extra-key case uses `timestamp` on purpose: `docs/VERIFIED_PROTOCOL.md`
already records that the field is `now`, not `timestamp`. This is the test that
would have caught that particular mistake, and the two acceptance cases keep the
opposite error from creeping in — someone "fixing" an optional field that was
never required.

## Result

```
$ node tests/test_client_schema.mjs
[ok] 17 local message envelopes accepted, 4 malformed rejected, 2 optional-field shapes accepted
```

No production code touched.

