### PR TITLE
docs(protocol): record that pong requires serverId

### DIFF
--- a/docs/VERIFIED_PROTOCOL.md
+++ b/docs/VERIFIED_PROTOCOL.md
@@ -94,7 +94,15 @@ Other validated types:
 - `dispatch_ack`
 - `event`
 - `error`
-- `pong` (uses `now`, not `timestamp`)
+- `pong` — `serverId` is **required**; `now` is an optional integer. The field is
+  `now`, never `timestamp`. Shipped schema:
+
+  ```js
+  pu = _({ type: I("pong"), serverId: Z(), now: H().int().optional() }).strict()
+  ```
+
+  A `pong` without `serverId` fails the strict parser and is dropped, so the
+  client never observes a reply to its ping.
 
 A successful committed dispatch acknowledgement requires:
 


### PR DESCRIPTION
## What

`docs/VERIFIED_PROTOCOL.md` lists:

> - `pong` (uses `now`, not `timestamp`)

That names the optional field and omits the required one.

## Evidence

From the shipped schema (`public/assets/i18n-DtIC1LRi.js`, alongside the other
envelope schemas):

```js
pu = _({ type: I("pong"), serverId: Z(), now: H().int().optional() }).strict()
```

`serverId` is required. `now` is an optional integer. Confirmed against the
parser itself:

```
accepted   { type: "pong", serverId: "x", now: 1 }
accepted   { type: "pong", serverId: "x" }              // now is optional
rejected   { type: "pong", now: 1 }                     // invalid_type: serverId
rejected   { type: "pong", serverId: "x", timestamp: 1 } // unrecognized_keys
```

## Why it is worth correcting

Someone implementing from the previous wording would send `{type, now}`. The
strict parser drops it, the client never observes a reply to its ping, and the
failure presents as a connection the client believes is dead — not as a schema
error.

`backend/session/world.py` already sends both fields, so this is a contract-text
fix only; no behaviour changes.

Related: #39 adds the parser cases that pin this (`pong` without `serverId` must
be rejected, `pong` without `now` must be accepted).

