### PR TITLE
feat(wallpaper): add dedicated desktop background mode

### DIFF
--- a/.github/workflows/settings-runtime.yml
+++ b/.github/workflows/settings-runtime.yml
@@ -10,6 +10,9 @@ on:
       - "cloudflare/entry.py"
       - "public/nori-ai-*.js"
       - "public/nori-tts-*.js"
+      - "public/nori-ui-settings.js"
+      - "public/nori-wallpaper-mode.js"
+      - "public/wallpaper.html"
       - "public/index.html"
       - "tests/test_ai_*.py"
       - "tests/test_tts_runtime_settings.py"
@@ -25,6 +28,9 @@ on:
       - "cloudflare/entry.py"
       - "public/nori-ai-*.js"
       - "public/nori-tts-*.js"
+      - "public/nori-ui-settings.js"
+      - "public/nori-wallpaper-mode.js"
+      - "public/wallpaper.html"
       - "public/index.html"
       - "tests/test_ai_*.py"
       - "tests/test_tts_runtime_settings.py"
@@ -64,6 +70,14 @@ jobs:
           node --check public/nori-ai-settings.js
           node --check public/nori-ai-provider-switch.js
           node --check public/nori-tts-settings.js
+          node --check public/nori-ui-settings.js
+          node --check public/nori-wallpaper-mode.js
+
+      - name: Verify wallpaper entry wiring
+        run: |
+          grep -q 'nori-wallpaper-mode.js' public/index.html
+          grep -q 'wallpaper' public/wallpaper.html
+          grep -q 'interactive' public/nori-wallpaper-mode.js
 
       - name: Compile settings services and Worker entry
         run: uv run python -m compileall -q backend/services cloudflare

--- a/docs/WALLPAPER_MODE.md
+++ b/docs/WALLPAPER_MODE.md
@@ -1,0 +1,50 @@
+# Nori desktop wallpaper mode
+
+Nori.Web exposes a dedicated presentation mode intended for desktop wallpaper hosts such as Lively Wallpaper or other tools that can render a web URL as a live background.
+
+## Hosted / local URL
+
+After starting Nori.Web, open:
+
+```text
+http://127.0.0.1:4173/wallpaper.html
+```
+
+`wallpaper.html` redirects to the normal application entry with `wallpaper=1`, so the same runtime, Live2D model and scene assets are reused without maintaining a second copy of the application shell.
+
+The equivalent direct URL is:
+
+```text
+http://127.0.0.1:4173/?wallpaper=1
+```
+
+Wallpaper mode is URL-scoped. It does not persist the ordinary **Hide GUI** setting, so visiting the normal Nori.Web URL later still uses the user's regular interface preference.
+
+## Interaction
+
+The default wallpaper mode keeps the presentation non-interactive so retained scene layers do not capture pointer input inside generic wallpaper hosts.
+
+For hosts that intentionally forward pointer input to the web wallpaper, use:
+
+```text
+http://127.0.0.1:4173/wallpaper.html?interactive=1
+```
+
+or:
+
+```text
+http://127.0.0.1:4173/?wallpaper=1&interactive=1
+```
+
+## Browser API
+
+`window.NoriWallpaperMode` exposes a small read-only helper API:
+
+```js
+NoriWallpaperMode.active
+NoriWallpaperMode.interactive
+NoriWallpaperMode.url({ interactive: true })
+NoriWallpaperMode.exit()
+```
+
+The existing `window.NoriUISettings` API remains responsible for the persistent browser **Hide GUI** preference.

--- a/public/index.html
+++ b/public/index.html
@@ -24,6 +24,9 @@
     <script src="/nori-ai-provider-switch.js"></script>
     <script src="/nori-tts-settings.js"></script>
     <script src="/nori-ui-settings.js"></script>
+    <!-- Dedicated URL-scoped wallpaper mode also runs before the historical app
+         so the desktop chrome is suppressed before its first rendered frame. -->
+    <script src="/nori-wallpaper-mode.js"></script>
     <!-- Keep the compatibility panels visually consistent with the native
          Settings pages by letting the Nori window glass show through. -->
     <link rel="stylesheet" href="/nori-settings-glass.css" />

--- a/public/nori-wallpaper-mode.js
+++ b/public/nori-wallpaper-mode.js
@@ -1,0 +1,88 @@
+(() => {
+  "use strict";
+
+  const WALLPAPER_CLASS = "nori-wallpaper-mode";
+  const INTERACTIVE_CLASS = "nori-wallpaper-interactive";
+  const HIDDEN_CLASS = "nori-gui-hidden";
+  const KEEP_ATTRIBUTE = "data-nori-gui-keep";
+
+  function buildWallpaperUrl(options = {}) {
+    const url = new URL(window.location.href);
+    url.searchParams.set("wallpaper", "1");
+    url.searchParams.delete("mode");
+    if (options.interactive === true) url.searchParams.set("interactive", "1");
+    else url.searchParams.delete("interactive");
+    return url.toString();
+  }
+
+  function isWallpaperMode() {
+    const params = new URLSearchParams(window.location.search);
+    return params.get("wallpaper") === "1" || params.get("mode") === "wallpaper";
+  }
+
+  const active = isWallpaperMode();
+  const interactive =
+    active && new URLSearchParams(window.location.search).get("interactive") === "1";
+
+  window.NoriWallpaperMode = Object.freeze({
+    active,
+    interactive,
+    url: (options) => buildWallpaperUrl(options),
+    exit() {
+      const url = new URL(window.location.href);
+      url.searchParams.delete("wallpaper");
+      if (url.searchParams.get("mode") === "wallpaper") url.searchParams.delete("mode");
+      url.searchParams.delete("interactive");
+      window.location.replace(url.toString());
+    },
+  });
+
+  if (!active) return;
+
+  const rootElement = document.documentElement;
+  rootElement.classList.add(WALLPAPER_CLASS, HIDDEN_CLASS);
+  rootElement.classList.toggle(INTERACTIVE_CLASS, interactive);
+  rootElement.dataset.noriWallpaper = "1";
+
+  // Wallpaper mode is URL-scoped instead of stored as the ordinary Hide GUI
+  // preference. Reassert the presentation class if a settings/storage update
+  // tries to restore the normal shell while this dedicated entry is active.
+  let enforcing = false;
+  function enforceWallpaperMode() {
+    if (enforcing) return;
+    enforcing = true;
+    rootElement.classList.add(WALLPAPER_CLASS, HIDDEN_CLASS);
+    rootElement.classList.toggle(INTERACTIVE_CLASS, interactive);
+    enforcing = false;
+  }
+
+  const classObserver = new MutationObserver(enforceWallpaperMode);
+  classObserver.observe(rootElement, { attributes: true, attributeFilter: ["class"] });
+  window.addEventListener("nori:ui-settings-changed", enforceWallpaperMode);
+
+  const style = document.createElement("style");
+  style.id = "nori-wallpaper-mode-style";
+  style.textContent = `
+    html.${WALLPAPER_CLASS},
+    html.${WALLPAPER_CLASS} body{
+      width:100%;height:100%;margin:0;overflow:hidden;background:#000;
+      overscroll-behavior:none;
+    }
+    html.${WALLPAPER_CLASS} body{position:fixed;inset:0}
+    html.${WALLPAPER_CLASS} #root{
+      width:100vw;height:100vh;overflow:hidden;user-select:none;
+    }
+    html.${WALLPAPER_CLASS}:not(.${INTERACTIVE_CLASS}) #root [${KEEP_ATTRIBUTE}="1"]{
+      pointer-events:none!important;
+    }
+  `;
+  document.head.appendChild(style);
+
+  // A small semantic hook for wallpaper hosts/debugging. The normal Nori.Web
+  // entry remains untouched because this event only fires in explicit mode.
+  window.dispatchEvent(
+    new CustomEvent("nori:wallpaper-mode", {
+      detail: { active: true, interactive },
+    }),
+  );
+})();

--- a/public/wallpaper.html
+++ b/public/wallpaper.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en" class="dark theme-nori">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="dark" />
+    <title>Nori Wallpaper</title>
+    <style>
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+        overflow: hidden;
+        background: #000;
+      }
+    </style>
+    <script>
+      (() => {
+        const current = new URL(window.location.href);
+        const target = new URL("./", current);
+        for (const [key, value] of current.searchParams) {
+          if (key !== "wallpaper") target.searchParams.append(key, value);
+        }
+        target.searchParams.set("wallpaper", "1");
+        target.hash = current.hash;
+        window.location.replace(target.toString());
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>


### PR DESCRIPTION
## Summary

Builds on the merged Hide GUI support and turns it into a dedicated **desktop wallpaper mode** for Nori.Web.

- adds `/wallpaper.html` as a direct wallpaper entry
- adds `?wallpaper=1` as the URL-scoped presentation mode
- keeps only Nori / scene background presentation while desktop GUI remains hidden
- does not persist or overwrite the normal browser Hide GUI preference
- applies wallpaper mode before the historical Vite app renders to avoid a normal-desktop first frame
- defaults retained scene layers to non-interactive presentation for generic wallpaper hosts
- supports `?interactive=1` for hosts that intentionally forward pointer input
- exposes `window.NoriWallpaperMode` helpers for status, URL generation and exiting wallpaper mode
- extends Settings Runtime CI to syntax-check the UI/wallpaper scripts and verify entry wiring
- documents local/hosted wallpaper URLs in `docs/WALLPAPER_MODE.md`

## Usage

```text
http://127.0.0.1:4173/wallpaper.html
```

Interactive variant:

```text
http://127.0.0.1:4173/wallpaper.html?interactive=1
```

Equivalent direct application URL:

```text
http://127.0.0.1:4173/?wallpaper=1
```

## Design

The dedicated entry reuses the existing production application, Live2D runtime and scene assets instead of maintaining a second copy of the Nori scene. Wallpaper state is URL-scoped, while the existing Settings > Interface > Hide GUI preference remains a normal persistent browser preference.

No merge is requested automatically.